### PR TITLE
🫡 [gha] try govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,21 @@
+name: govulncheck
+on:
+  push:
+  pull_request:
+  schedule: # daily at 10:22 UTC
+    - cron: '22 10 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: |
+          go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## Context

Looking for alternatives to dependabot, I read https://words.filippo.io/dependabot/ which encouraged me to try this.

<!-- PR_BODY_DONE_START -->
## Done

- 🫡 [gha] try govulncheck

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
