### PR TITLE
🐌 [src] work around two bugs in name handling 1. Line 89-93: Truncation now accounts for … being 3 bytes (not 1), preventing the truncated string from exceeding maxWidth 2. Line 107-111: Added guard against negative padding in BuildNameColumn

### DIFF
--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -87,7 +87,12 @@ func FormatCheckName(check ghclient.CheckRunInfo) string {
 func FormatCheckNameWithTruncate(check ghclient.CheckRunInfo, maxWidth int) string {
 	name := FormatCheckName(check)
 	if len(name) > maxWidth {
-		return name[:maxWidth-1] + "…"
+		ellipsis := "…"
+		truncateAt := maxWidth - len(ellipsis)
+		if truncateAt < 0 {
+			truncateAt = 0
+		}
+		return name[:truncateAt] + ellipsis
 	}
 	return name
 }
@@ -106,7 +111,11 @@ func FormatLink(url, text string) string {
 // len()-based width measurement stays accurate for the rest of the line.
 func BuildNameColumn(check ghclient.CheckRunInfo, widths ColumnWidths, enableLinks bool) string {
 	name := FormatCheckNameWithTruncate(check, widths.NameWidth)
-	padding := strings.Repeat(" ", widths.NameWidth-len(name))
+	paddingLen := widths.NameWidth - len(name)
+	if paddingLen < 0 {
+		paddingLen = 0
+	}
+	padding := strings.Repeat(" ", paddingLen)
 	if enableLinks && check.DetailsURL != "" {
 		return FormatLink(check.DetailsURL, name) + padding
 	}


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🐌 [src] work around two bugs in name handling 1. Line 89-93: Truncation now accounts for … being 3 bytes (not 1), preventing the truncated string from exceeding maxWidth 2. Line 107-111: Added guard against negative padding in BuildNameColumn

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
