### PR TITLE
🧗 [go] upgrade go from v1.25.7 to v1.26.1 to fix crypt() vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fini-net/gh-observer
 
-go 1.25.7
+go 1.26.1
 
 require (
 	charm.land/bubbles/v2 v2.0.0


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🧗 [go] upgrade go from v1.25.7 to v1.26.1 to fix crypt() vulnerability

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
