### PR TITLE
🎀 [src] supporting URLs means you can gh-observer any repo at any time, fixes #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,24 @@ just build
 gh observer
 ```
 
-### Watch specific PR
+### Watch specific PR in current repo
 
 ```bash
 gh observer 123
 ```
+
+### Watch external PR by URL
+
+You can watch checks on any public PR by passing the full URL - no need to clone the repo:
+
+```bash
+gh observer https://github.com/StackExchange/dnscontrol/pull/3941
+```
+
+This works for any GitHub PR URL and is useful for:
+- Reviewing checks on a colleague's PR in another repo
+- Monitoring upstream dependencies before merging
+- Following CI status on projects you don't have cloned locally
 
 ### Use in CI pipelines
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -65,6 +65,20 @@ func parseOwnerRepoFromURL(url string) (string, string, error) {
 	return "", "", fmt.Errorf("unable to parse owner/repo from remote URL: %s", url)
 }
 
+// ParsePRURL extracts owner, repo, and PR number from a GitHub PR URL
+func ParsePRURL(prURL string) (owner, repo string, prNumber int, err error) {
+	pattern := regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)$`)
+	matches := pattern.FindStringSubmatch(prURL)
+	if len(matches) != 4 {
+		return "", "", 0, fmt.Errorf("invalid PR URL: %s (expected https://github.com/owner/repo/pull/NNN)", prURL)
+	}
+	prNum, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR number: %w", err)
+	}
+	return matches[1], matches[2], prNum, nil
+}
+
 // FetchPRInfo retrieves metadata about a pull request
 func FetchPRInfo(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (*PRInfo, error) {
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -4,6 +4,115 @@ import (
 	"testing"
 )
 
+func TestParsePRURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantPRNum int
+		wantErr   bool
+	}{
+		{
+			name:      "valid HTTPS URL",
+			url:       "https://github.com/fini-net/gh-observer/pull/88",
+			wantOwner: "fini-net",
+			wantRepo:  "gh-observer",
+			wantPRNum: 88,
+			wantErr:   false,
+		},
+		{
+			name:      "valid HTTP URL",
+			url:       "http://github.com/owner/repo/pull/123",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantPRNum: 123,
+			wantErr:   false,
+		},
+		{
+			name:      "owner with hyphens and numbers",
+			url:       "https://github.com/org-123/repo-name/pull/456",
+			wantOwner: "org-123",
+			wantRepo:  "repo-name",
+			wantPRNum: 456,
+			wantErr:   false,
+		},
+		{
+			name:      "repo with dots",
+			url:       "https://github.com/owner/repo.name/pull/789",
+			wantOwner: "owner",
+			wantRepo:  "repo.name",
+			wantPRNum: 789,
+			wantErr:   false,
+		},
+		{
+			name:    "missing protocol",
+			url:     "github.com/owner/repo/pull/123",
+			wantErr: true,
+		},
+		{
+			name:    "wrong host",
+			url:     "https://gitlab.com/owner/repo/pull/123",
+			wantErr: true,
+		},
+		{
+			name:    "wrong path format - issues",
+			url:     "https://github.com/owner/repo/issues/123",
+			wantErr: true,
+		},
+		{
+			name:    "missing pull number",
+			url:     "https://github.com/owner/repo/pull/",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric PR number",
+			url:     "https://github.com/owner/repo/pull/abc",
+			wantErr: true,
+		},
+		{
+			name:    "trailing slash",
+			url:     "https://github.com/owner/repo/pull/123/",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "just github.com",
+			url:     "https://github.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOwner, gotRepo, gotPRNum, err := ParsePRURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParsePRURL(%q) expected error, got nil", tt.url)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParsePRURL(%q) unexpected error: %v", tt.url, err)
+				return
+			}
+			if gotOwner != tt.wantOwner {
+				t.Errorf("ParsePRURL(%q) owner = %q, want %q", tt.url, gotOwner, tt.wantOwner)
+			}
+			if gotRepo != tt.wantRepo {
+				t.Errorf("ParsePRURL(%q) repo = %q, want %q", tt.url, gotRepo, tt.wantRepo)
+			}
+			if gotPRNum != tt.wantPRNum {
+				t.Errorf("ParsePRURL(%q) PR number = %d, want %d", tt.url, gotPRNum, tt.wantPRNum)
+			}
+		})
+	}
+}
+
 func TestParseOwnerRepoFromURL(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -23,11 +24,14 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "gh-observer [PR_NUMBER]",
+	Use:   "gh-observer [PR_NUMBER | PR_URL]",
 	Short: "Watch GitHub PR checks with runtime metrics",
 	Long: `gh-observer is a GitHub PR check watcher CLI tool that improves on 
 'gh pr checks --watch' by showing runtime metrics, queue latency, 
-and better handling of startup delays.`,
+and better handling of startup delays.
+
+Supports watching checks on external repositories by passing a full PR URL:
+  gh-observer https://github.com/owner/repo/pull/123`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		exitCode := run(args)
@@ -129,31 +133,49 @@ func run(args []string) int {
 	)
 
 	// Parse arguments
+	var owner, repo string
 	var prNumber int
+
 	if len(args) > 0 {
-		// PR number provided as argument
-		n, err := strconv.Atoi(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid PR number: %s\n", args[0])
-			return 1
+		arg := args[0]
+		// Check if argument is a PR URL
+		if strings.Contains(arg, "github.com") && strings.Contains(arg, "/pull/") {
+			// URL provided: parse owner/repo/number from URL
+			owner, repo, prNumber, err = ghclient.ParsePRURL(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to parse PR URL: %v\n", err)
+				return 1
+			}
+		} else {
+			// PR number provided: parse number, get owner/repo from git remote
+			n, err := strconv.Atoi(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Invalid PR number or URL: %s\n", arg)
+				return 1
+			}
+			prNumber = n
+
+			owner, repo, err = ghclient.ParseOwnerRepo()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to parse repository: %v\n", err)
+				return 1
+			}
 		}
-		prNumber = n
 	} else {
 		// Auto-detect PR from current branch
 		n, err := ghclient.GetCurrentPR()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to detect PR: %v\n", err)
-			fmt.Fprintf(os.Stderr, "Make sure you're on a PR branch or provide a PR number: gh-observer <number>\n")
+			fmt.Fprintf(os.Stderr, "Make sure you're on a PR branch or provide a PR number or URL\n")
 			return 1
 		}
 		prNumber = n
-	}
 
-	// Get owner and repo
-	owner, repo, err := ghclient.ParseOwnerRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse repository: %v\n", err)
-		return 1
+		owner, repo, err = ghclient.ParseOwnerRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse repository: %v\n", err)
+			return 1
+		}
 	}
 
 	// Get GitHub token


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🎀 [src] supporting URLs means you can gh-observer any repo at any time, fixes #88

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
