### PR TITLE
🙉 [git] ignore .opencode/package-lock.json

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,7 @@
+{
+  "threshold": 0,
+  "absolute": true,
+  "ignore": [
+    "**/docs/**"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ go.work.sum
 /.opencode/plans/
 /.opencode/bun.lock
 /.opencode/package.json
+/.opencode/package-lock.json

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,7 +1,0 @@
-{
-  "threshold": 0,
-  "ignore": [
-    "**/docs/**",
-    "docs/*"
-  ]
-}

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,6 @@
+{
+  "threshold": 0,
+  "ignore": [
+    "**/docs/**"
+  ]
+}

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,6 +1,7 @@
 {
   "threshold": 0,
   "ignore": [
-    "**/docs/**"
+    "**/docs/**",
+    "docs/*"
   ]
 }


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🙉 [git] ignore .opencode/package-lock.json
- add ignores for jscpd so the docs directory does not matter
- improve igoring docs/* for jscpd
- put jscpd.json where the super-linter runs will find it

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)



