### PR TITLE
🔣 [src] use runewidth over utf8 to avoid column alignment issues, fixes #188

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ runtime metrics, queue latency, and better handling of startup delays.
 
 ## Why?
 
-The existing `gh pr checks --watch` doesn't show how long checks have been running, doesn't handle the 30-90s startup delay well, and doesn't show queue latency. This creates anxiety when watching CI runs - "is it stuck or just slow?"
+The existing `gh pr checks --watch` doesn't show how long checks have been
+running, doesn't handle the 30-90s startup delay well, and doesn't show queue
+latency. This creates anxiety when watching CI runs - "is it stuck or just
+slow?"
 
 ## Features
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/google/go-github/v84 v84.0.0
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/muesli/termenv v0.16.0
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	github.com/spf13/cobra v1.10.2
@@ -35,7 +36,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -126,10 +126,10 @@ func FormatLink(url, text string) string {
 	return termenv.Hyperlink(url, text)
 }
 
-// BuildNameColumn returns a left-aligned name column of exactly widths.NameWidth visible
-// characters. If enableLinks is true and the check has a DetailsURL, the visible text is
-// wrapped in an OSC 8 hyperlink; padding spaces are appended outside the link so that
-// rune-based width measurement stays accurate for the rest of the line.
+// BuildNameColumn returns a left-aligned name column of exactly widths.NameWidth
+// terminal display cells. If enableLinks is true and the check has a DetailsURL, the
+// visible text is wrapped in an OSC 8 hyperlink; padding spaces are appended outside
+// the link so that display-width measurement stays accurate for the rest of the line.
 func BuildNameColumn(check ghclient.CheckRunInfo, widths ColumnWidths, enableLinks bool) string {
 	name := FormatCheckNameWithTruncate(check, widths.NameWidth)
 	paddingLen := max(widths.NameWidth-runewidth.StringWidth(name), 0)

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 	"github.com/fini-net/gh-observer/internal/timing"
+	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 )
 
@@ -96,44 +96,26 @@ func FormatCheckName(check ghclient.CheckRunInfo) string {
 // FormatCheckNameWithTruncate formats the check name and truncates if needed
 func FormatCheckNameWithTruncate(check ghclient.CheckRunInfo, maxWidth int) string {
 	name := FormatCheckName(check)
-	if utf8.RuneCountInString(name) <= maxWidth {
+	if runewidth.StringWidth(name) <= maxWidth {
 		return name
 	}
 
-	ellipsis := "…"
-
-	// If there's a workflow name, try to preserve "Workflow / " structure
 	if check.WorkflowName != "" {
 		prefix := check.WorkflowName + " / "
-		prefixRunes := utf8.RuneCountInString(prefix)
+		prefixWidth := runewidth.StringWidth(prefix)
 
-		// If even the prefix alone exceeds maxWidth, truncate the whole string
-		if prefixRunes >= maxWidth {
-			if maxWidth <= 1 {
-				return string([]rune(ellipsis)[:maxWidth])
-			}
-			return string([]rune(name)[:maxWidth-1]) + ellipsis
+		if prefixWidth >= maxWidth {
+			return runewidth.Truncate(name, maxWidth, "…")
 		}
 
-		jobRunes := []rune(check.Name)
-		availableWidth := maxWidth - prefixRunes - 1 // -1 for ellipsis display cell
-		if availableWidth <= 0 {
-			if maxWidth <= 1 {
-				return string([]rune(ellipsis)[:maxWidth])
-			}
-			return string([]rune(name)[:maxWidth-1]) + ellipsis
-		}
-		if availableWidth >= len(jobRunes) {
+		remainingWidth := maxWidth - prefixWidth
+		if runewidth.StringWidth(check.Name) <= remainingWidth {
 			return prefix + check.Name
 		}
-		return prefix + string(jobRunes[:availableWidth]) + ellipsis
+		return prefix + runewidth.Truncate(check.Name, remainingWidth, "…")
 	}
 
-	// No workflow name - simple truncation
-	if maxWidth <= 1 {
-		return string([]rune(ellipsis)[:maxWidth])
-	}
-	return string([]rune(name)[:maxWidth-1]) + ellipsis
+	return runewidth.Truncate(name, maxWidth, "…")
 }
 
 // FormatLink wraps text in an OSC 8 terminal hyperlink
@@ -150,7 +132,7 @@ func FormatLink(url, text string) string {
 // rune-based width measurement stays accurate for the rest of the line.
 func BuildNameColumn(check ghclient.CheckRunInfo, widths ColumnWidths, enableLinks bool) string {
 	name := FormatCheckNameWithTruncate(check, widths.NameWidth)
-	paddingLen := max(widths.NameWidth-utf8.RuneCountInString(name), 0)
+	paddingLen := max(widths.NameWidth-runewidth.StringWidth(name), 0)
 	padding := strings.Repeat(" ", paddingLen)
 	if enableLinks && check.DetailsURL != "" {
 		return FormatLink(check.DetailsURL, name) + padding
@@ -187,12 +169,12 @@ func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime tim
 
 	for _, check := range checkRuns {
 		queueText := FormatQueueLatency(check, headCommitTime)
-		if utf8.RuneCountInString(queueText) > widths.QueueWidth {
-			widths.QueueWidth = utf8.RuneCountInString(queueText)
+		if runewidth.StringWidth(queueText) > widths.QueueWidth {
+			widths.QueueWidth = runewidth.StringWidth(queueText)
 		}
 
 		name := FormatCheckName(check)
-		nameLen := utf8.RuneCountInString(name)
+		nameLen := runewidth.StringWidth(name)
 		if nameLen > widths.NameWidth && nameLen <= maxNameWidth {
 			widths.NameWidth = nameLen
 		} else if nameLen > maxNameWidth {
@@ -200,13 +182,13 @@ func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime tim
 		}
 
 		durationText := FormatDuration(check)
-		if utf8.RuneCountInString(durationText) > widths.DurationWidth {
-			widths.DurationWidth = utf8.RuneCountInString(durationText)
+		if runewidth.StringWidth(durationText) > widths.DurationWidth {
+			widths.DurationWidth = runewidth.StringWidth(durationText)
 		}
 
 		avgText := FormatAvg(check, jobAverages)
-		if utf8.RuneCountInString(avgText) > widths.AvgWidth {
-			widths.AvgWidth = utf8.RuneCountInString(avgText)
+		if runewidth.StringWidth(avgText) > widths.AvgWidth {
+			widths.AvgWidth = runewidth.StringWidth(avgText)
 		}
 	}
 
@@ -215,16 +197,16 @@ func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime tim
 
 // FormatAlignedColumns formats the four columns with proper padding
 func FormatAlignedColumns(queueText, nameText, durationText, avgText string, widths ColumnWidths) (string, string, string, string) {
-	queuePadding := max(widths.QueueWidth-utf8.RuneCountInString(queueText), 0)
+	queuePadding := max(widths.QueueWidth-runewidth.StringWidth(queueText), 0)
 	queueCol := strings.Repeat(" ", queuePadding) + queueText
 
-	namePadding := max(widths.NameWidth-utf8.RuneCountInString(nameText), 0)
+	namePadding := max(widths.NameWidth-runewidth.StringWidth(nameText), 0)
 	nameCol := nameText + strings.Repeat(" ", namePadding)
 
-	durationPadding := max(widths.DurationWidth-utf8.RuneCountInString(durationText), 0)
+	durationPadding := max(widths.DurationWidth-runewidth.StringWidth(durationText), 0)
 	durationCol := strings.Repeat(" ", durationPadding) + durationText
 
-	avgPadding := max(widths.AvgWidth-utf8.RuneCountInString(avgText), 0)
+	avgPadding := max(widths.AvgWidth-runewidth.StringWidth(avgText), 0)
 	avgCol := strings.Repeat(" ", avgPadding) + avgText
 
 	return queueCol, nameCol, durationCol, avgCol
@@ -256,10 +238,7 @@ func FormatDescription(description string, widths ColumnWidths) string {
 	}
 	totalWidth := widths.QueueWidth + 1 + 1 + widths.NameWidth + 2 + widths.DurationWidth + 2 + widths.AvgWidth
 	maxLen := max(totalWidth-4, 20)
-	if utf8.RuneCountInString(description) > maxLen {
-		return string([]rune(description)[:maxLen-1]) + "…"
-	}
-	return description
+	return runewidth.Truncate(description, maxLen, "…")
 }
 
 // SortCheckRuns sorts check runs with three criteria:

--- a/internal/tui/display_test.go
+++ b/internal/tui/display_test.go
@@ -145,7 +145,7 @@ func TestFormatCheckNameWithTruncate(t *testing.T) {
 				Name:         "テストビルド",
 			},
 			maxWidth: 10,
-			want:     "CI / テストビ…",
+			want:     "CI / テス…",
 		},
 		{
 			name: "emoji in job name no truncation",
@@ -163,7 +163,7 @@ func TestFormatCheckNameWithTruncate(t *testing.T) {
 				Name:         "🚀 deploy-prod",
 			},
 			maxWidth: 15,
-			want:     "Build / 🚀 depl…",
+			want:     "Build / 🚀 dep…",
 		},
 		{
 			name: "CJK workflow name truncation",
@@ -172,7 +172,7 @@ func TestFormatCheckNameWithTruncate(t *testing.T) {
 				Name:         "テスト",
 			},
 			maxWidth: 10,
-			want:     "検証ワークフロー …",
+			want:     "検証ワー…",
 		},
 		{
 			name: "no workflow CJK truncation",
@@ -181,7 +181,7 @@ func TestFormatCheckNameWithTruncate(t *testing.T) {
 				Name:         "ビルドテスト実行",
 			},
 			maxWidth: 5,
-			want:     "ビルドテ…",
+			want:     "ビル…",
 		},
 	}
 
@@ -234,8 +234,8 @@ func TestBuildNameColumnCJK(t *testing.T) {
 		Name:         "ビルド",
 	}
 	got := BuildNameColumn(check, widths, false)
-	// "CI / ビルド" = 8 runes, so 12 padding spaces
-	want := "CI / ビルド            "
+	// "CI / ビルド" has display width 11, so 9 padding spaces
+	want := "CI / ビルド         "
 	if got != want {
 		t.Errorf("BuildNameColumn() = %q, want %q", got, want)
 	}
@@ -249,19 +249,19 @@ func TestFormatAlignedColumnsCJK(t *testing.T) {
 		AvgWidth:      5,
 	}
 	queueCol, nameCol, durationCol, avgCol := FormatAlignedColumns("30s", "ビルド", "1m", "--", widths)
-	// "ビルド" = 3 runes, NameWidth=10, padding=7
-	if nameCol != "ビルド       " {
-		t.Errorf("nameCol = %q, want %q", nameCol, "ビルド       ")
+	// "ビルド" has display width 6, NameWidth=10, padding=4
+	if nameCol != "ビルド    " {
+		t.Errorf("nameCol = %q, want %q", nameCol, "ビルド    ")
 	}
-	// "30s" = 3 runes, QueueWidth=5, padding=2
+	// "30s" = 3 display cells, QueueWidth=5, padding=2
 	if queueCol != "  30s" {
 		t.Errorf("queueCol = %q, want %q", queueCol, "  30s")
 	}
-	// "1m" = 2 runes, DurationWidth=5, padding=3
+	// "1m" = 2 display cells, DurationWidth=5, padding=3
 	if durationCol != "   1m" {
 		t.Errorf("durationCol = %q, want %q", durationCol, "   1m")
 	}
-	// "--" = 2 runes, AvgWidth=5, padding=3
+	// "--" = 2 display cells, AvgWidth=5, padding=3
 	if avgCol != "   --" {
 		t.Errorf("avgCol = %q, want %q", avgCol, "   --")
 	}
@@ -277,11 +277,11 @@ func TestCalculateColumnWidthsCJK(t *testing.T) {
 	}
 	widths := CalculateColumnWidths(checks, time.Time{}, nil)
 
-	// "🚀配信ワークフロー実行プロセス / deploy" = 24 runes
-	// "ビルドテスト実行チェックを確認するプロセス" = 21 runes
-	// max of these is 24
-	if widths.NameWidth != 24 {
-		t.Errorf("NameWidth = %d, want 24", widths.NameWidth)
+	// "🚀配信ワークフロー実行プロセス / deploy" has display width 39
+	// "ビルドテスト実行チェックを確認するプロセス" has display width 42, capped at maxNameWidth=60
+	// max of these display widths is 42
+	if widths.NameWidth != 42 {
+		t.Errorf("NameWidth = %d, want 42", widths.NameWidth)
 	}
 }
 
@@ -293,9 +293,9 @@ func TestFormatDescriptionCJK(t *testing.T) {
 		AvgWidth:      5,
 	}
 	// totalWidth = 5+1+1+10+2+5+2+5 = 31, maxLen = 27
-	// 29 CJK runes > 27, so truncate to 26 runes + "…"
+	// Display width of the CJK string is 58, truncated to 27 display cells
 	got := FormatDescription("テスト実行の詳細説明を入力してくださいここに追加情報ですよ", widths)
-	want := "テスト実行の詳細説明を入力してくださいここに追加情報…"
+	want := "テスト実行の詳細説明を入力…"
 	if got != want {
 		t.Errorf("FormatDescription() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🔣 [src] use runewidth over utf8 to avoid column alignment issues, fixes #188
- improve comment at copilots suggestion
- README tweak to test if claude code review is working again

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)


