### PR TITLE
fix: replace invalid excludeManagers with matchManagers negation in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,13 +18,13 @@
     },
     {
       "matchUpdateTypes": ["patch"],
-      "excludeManagers": ["github-actions"],
+      "matchManagers": ["!github-actions"],
       "groupName": "patches",
       "automerge": true
     },
     {
       "matchUpdateTypes": ["minor"],
-      "excludeManagers": ["github-actions"],
+      "matchManagers": ["!github-actions"],
       "groupName": "minor updates",
       "automerge": true
     },


### PR DESCRIPTION
Replaces the invalid `excludeManagers` option with the supported `matchManagers` negation pattern (`!github-actions`) in two packageRules entries.

Renovate does not support `excludeManagers` — the correct approach is `matchManagers: ["!github-actions"]`.

Closes #294