### PR TITLE
🌂 [gha] unpin slsa-github-generator since pinning broke it

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,20 +37,20 @@ jobs:
 
       - name: Validate PR inputs
         id: validate
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
-          # Validate github.repository matches expected pattern (owner/repo)
-          if ! echo "${{ github.repository }}" | grep -qE '^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$'; then
-            echo "::error::Invalid repository format: ${{ github.repository }}"
+          if ! echo "$REPO" | grep -qE '^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$'; then
+            echo "::error::Invalid repository format: $REPO"
             exit 1
           fi
-          # Validate PR number is a positive integer
-          pr_num="${{ github.event.pull_request.number }}"
-          if ! echo "$pr_num" | grep -qE '^[1-9][0-9]*$'; then
-            echo "::error::Invalid PR number: $pr_num"
+          if ! echo "$PR_NUM" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::Invalid PR number: $PR_NUM"
             exit 1
           fi
-          echo "repository=${{ github.repository }}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$pr_num" >> "$GITHUB_OUTPUT"
+          echo "repository=$REPO" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
       actions: read
       id-token: write
       contents: write
+    # SLSA generator requires a tag ref (refs/tags/vX.Y.Z) for its internal builder checkout;
+    # pinning to a git SHA causes "Invalid ref" errors and provenance generation failure.
+    # See: https://github.com/fini-net/gh-observer/actions/runs/27281001944
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     # SLSA generator requires a tag ref (refs/tags/vX.Y.Z) for its internal builder checkout;
     # pinning to a git SHA causes "Invalid ref" errors and provenance generation failure.
     # See: https://github.com/fini-net/gh-observer/actions/runs/27281001944
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -15,7 +15,7 @@ on:
     branches: ["main"]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/vex.yml
+++ b/.github/workflows/vex.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Install vexctl
         run: go install github.com/openvex/vexctl@latest

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,7 +3,5 @@ rules:
   unpinned-uses:
     config:
       policies:
-        "actions/*": ref-pin
-        "github/*": ref-pin
-        "slsa-framework/slsa-github-generator": ref
-        "*": ref-pin
+        "slsa-framework/slsa-github-generator/*": ref-pin
+        "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,4 +5,5 @@ rules:
       policies:
         "actions/*": ref-pin
         "github/*": ref-pin
+        "slsa-framework/slsa-github-generator": ref
         "*": ref-pin


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🌂 [gha] unpin slsa-github-generator since pinning broke it
- comment to clarify why it is not pinned to gitsha
- better fixes for various zizmor complaints
- an ingore comment was needed

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)


