### PR TITLE
🔭 [src] add --repo watcher mode

### DIFF
--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -1,8 +1,15 @@
 # Example configuration for gh-observer
 # Copy to ~/.config/gh-observer/config.yaml to customize
 
-# Refresh interval for polling GitHub API
+# Refresh interval for polling GitHub API (single PR/run mode)
 refresh_interval: 5s
+
+# Refresh interval for repo mode (--repo flag)
+repo_refresh_interval: 30s
+
+# How long completed checks remain visible before fading out (repo mode)
+fade_success: 15m  # Successful checks disappear after 15 minutes
+fade_failure: 30m  # Failed checks disappear after 30 minutes
 
 # Color codes for terminal output (ANSI 256-color palette)
 colors:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 ![GitHub License](https://img.shields.io/github/license/fini-net/gh-observer)
 ![GitHub watchers](https://img.shields.io/github/watchers/fini-net/gh-observer)
 
-A GitHub PR check and Actions run watcher that improves on `gh pr checks --watch`
-by showing runtime metrics, queue latency, and better handling of startup delays.
+A GitHub PR check, Actions run, and repo watcher that improves on
+`gh pr checks --watch` by showing runtime metrics, queue latency, and better
+handling of startup delays. It can also persistently watch all active
+workflows across a repository with `--repo`.
 
 ![project banner: abstract representation of code flowing through a pull request, using interconnected nodes and lines.](docs/gh-observer-banner.jpeg)
 
@@ -31,8 +33,11 @@ slow?"
   start..." during the 30-90s GitHub delay
 - 🔧 **Actions run watching** - Monitor any GitHub Actions workflow run by
   URL, not just PR checks
+- 🔭 **Repo watcher** - `--repo` persistently monitors all active workflows
+  across a repo (PR checks grouped per PR plus standalone branch runs), with
+  completed checks fading out after configurable windows
 - 🛡️ **Rate limits** - Backs off automatically when approaching API limits to
-  avoid interruptions
+  avoid interruptions (refresh interval triples below 10 remaining)
 - 📊 **Historical averages** - Shows average runtime for each job based on
   recent completed runs, so you know if things are taking longer than usual
 - ⚡ **`--quick` mode** - Skip the historical averages fetch when you just want
@@ -204,6 +209,64 @@ the head commit was pushed (or when the run was created if commit info is
 unavailable). Exit code follows the same convention: 0 if all jobs succeed,
 1 if any job fails.
 
+### Watch all active workflows on a repo
+
+`--repo` opens a persistent overview of every active workflow on a repository.
+It shows open PRs (each with its checks grouped underneath) alongside
+standalone non-PR workflow runs (post-merge, scheduled, or `workflow_dispatch`)
+grouped by branch. Completed checks fade out of the view after a configurable
+window so the screen stays focused on what's still active. Repo mode is
+always interactive — it keeps running until you quit with `q`/`ctrl+c` and
+never auto-exits.
+
+```bash
+# Auto-detect owner/repo from the current git remote's origin URL
+gh observer --repo
+
+# Explicit owner/repo slug
+gh observer --repo owner/repo
+
+# Or a full GitHub URL
+gh observer --repo https://github.com/owner/repo
+```
+
+Bare `--repo` also accepts a trailing positional, so `gh observer --repo owner/repo`
+works (only `--repo=VALUE` rejects positionals). `--repo` cannot be combined
+with `--quick` and requires an interactive terminal — snapshot mode is rejected
+since a persistent watcher has no one-shot output.
+
+```ShellOutput
+fini-net/gh-observer  15:04:05 UTC
+3 active PRs  •  1 branch run  •  Updated 4s ago
+
+PR #142: Refactor token handling
+  15s ✓ CUE Validation / verify                        6s         -
+  15s ✓ Lint GitHub Actions workflows / actionlint     8s         -
+  12s ◐ Claude Code Review / claude-review           1m 32s       -
+
+PR #138: Fix fade-out window edge case
+  2m  ✓ CI / test                                    1m 40s       -
+  1m  ✗ CI / lint                                       45s       -
+
+PR #137: Update docs
+  3m  ✓ MarkdownLint / lint                              5s        -
+
+Branch: main
+  ✓ Deploy to staging (deploy)                          2m 10s
+    ✓ CI / build                                       1m 20s
+    ✓ CI / deploy                                        50s
+  ◐ CI / release (schedule)                            1m 05s
+    ◐ build                                           1m 05s
+
+Press q to quit
+```
+
+PR groups show each check's queue latency, runtime, and historical average
+(when available). Standalone branch runs show a run header (icon, title,
+event annotation, elapsed time) followed by indented job rows. Transient
+fetch errors (e.g. 504 Gateway Timeout) do not replace the screen: the last
+good state stays visible with a red error line so polling can self-heal.
+
 ### Skip historical averages for a faster snapshot
 
 If you just want a quick look without waiting for the historical averages
@@ -216,7 +279,7 @@ gh observer -q 123
 
 This skips the extra API calls for historical job runtimes and prints
 immediately. Useful when you're in a hurry or don't have the API budget
-to spare.
+to spare. `--quick` cannot be combined with `--repo`.
 
 ### Use in CI pipelines
 
@@ -236,8 +299,15 @@ gh observer https://github.com/owner/repo/actions/runs/123456789 && echo "All jo
 Create `~/.config/gh-observer/config.yaml` to customize settings:
 
 ```yaml
-# Refresh interval for polling GitHub API
+# Refresh interval for polling GitHub API (single PR/run mode)
 refresh_interval: 5s
+
+# Refresh interval for repo mode (--repo flag)
+repo_refresh_interval: 30s
+
+# How long completed checks remain visible before fading out (repo mode)
+fade_success: 15m  # Successful checks disappear after 15 minutes
+fade_failure: 30m  # Failed checks disappear after 30 minutes
 
 # Color codes for terminal output (ANSI 256-color palette)
 colors:
@@ -436,6 +506,13 @@ Built with:
 - [Lipgloss](https://github.com/charmbracelet/lipgloss) - Terminal styling
 - [go-github](https://github.com/google/go-github) - GitHub API client
 - [Viper](https://github.com/spf13/viper) - Configuration management
+
+The application has three execution modes: PR mode (watch a pull request's
+checks), run mode (watch a standalone Actions workflow run), and repo mode
+(`--repo`, which persistently watches all active workflows across a repo via
+a batched GraphQL query capped at the 10 most-recently-updated open PRs plus
+a REST fetch of standalone workflow runs, applying fade-out filtering to
+completed checks).
 
 See `CLAUDE.md` for detailed implementation notes.  Read the [linear walkthrough](docs/linear-walkthrough.md)
 to get a detailed walkthrough of the code and to learn why some

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,9 +18,12 @@ type ColorConfig struct {
 }
 
 type Config struct {
-	RefreshInterval time.Duration `mapstructure:"refresh_interval"`
-	Colors          ColorConfig   `mapstructure:"colors"`
-	EnableLinks     bool          `mapstructure:"enable_links"`
+	RefreshInterval     time.Duration `mapstructure:"refresh_interval"`
+	RepoRefreshInterval time.Duration `mapstructure:"repo_refresh_interval"`
+	FadeSuccess         time.Duration `mapstructure:"fade_success"`
+	FadeFailure         time.Duration `mapstructure:"fade_failure"`
+	Colors              ColorConfig   `mapstructure:"colors"`
+	EnableLinks         bool          `mapstructure:"enable_links"`
 }
 
 func Load() (*Config, error) {
@@ -28,6 +31,9 @@ func Load() (*Config, error) {
 
 	// Set defaults
 	v.SetDefault("refresh_interval", "5s")
+	v.SetDefault("repo_refresh_interval", "30s")
+	v.SetDefault("fade_success", "15m")
+	v.SetDefault("fade_failure", "30m")
 	v.SetDefault("colors.success", 10) // Green
 	v.SetDefault("colors.failure", 9)  // Red
 	v.SetDefault("colors.running", 11) // Yellow

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,15 @@ func TestLoad_DefaultValues(t *testing.T) {
 	if cfg.RefreshInterval != 5*time.Second {
 		t.Errorf("RefreshInterval = %v, want 5s", cfg.RefreshInterval)
 	}
+	if cfg.RepoRefreshInterval != 30*time.Second {
+		t.Errorf("RepoRefreshInterval = %v, want 30s", cfg.RepoRefreshInterval)
+	}
+	if cfg.FadeSuccess != 15*time.Minute {
+		t.Errorf("FadeSuccess = %v, want 15m", cfg.FadeSuccess)
+	}
+	if cfg.FadeFailure != 30*time.Minute {
+		t.Errorf("FadeFailure = %v, want 30m", cfg.FadeFailure)
+	}
 	if cfg.Colors.Success != 10 {
 		t.Errorf("Colors.Success = %d, want 10", cfg.Colors.Success)
 	}

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -1,0 +1,52 @@
+package github
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/fini-net/gh-observer/internal/debug"
+)
+
+var (
+	repoSlugPattern  = regexp.MustCompile(`^([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)$`)
+	repoURLPattern   = regexp.MustCompile(`^https?://github\.com/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+?)(?:\.git)?/?$`)
+	gitSSHRemoteRE   = regexp.MustCompile(`^git@github\.com:([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+?)(?:\.git)?/?$`)
+	gitHTTPSRemoteRE = regexp.MustCompile(`^https?://github\.com/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+?)(?:\.git)?/?$`)
+)
+
+// ParseRepoArg extracts owner and repo from a string in "owner/repo" or
+// "https://github.com/owner/repo" format. PR URLs and Actions run URLs are
+// rejected — this is only for repo-level arguments.
+func ParseRepoArg(arg string) (owner, repo string, err error) {
+	if m := repoSlugPattern.FindStringSubmatch(arg); len(m) == 3 {
+		return m[1], m[2], nil
+	}
+	if m := repoURLPattern.FindStringSubmatch(arg); len(m) == 3 {
+		return m[1], m[2], nil
+	}
+	return "", "", fmt.Errorf("invalid repo argument: %q (expected \"owner/repo\" or \"https://github.com/owner/repo\")", arg)
+}
+
+// GetCurrentRepo detects the owner and repo from the current git remote.
+// It reads the "origin" remote URL and extracts owner/repo from either SSH
+// or HTTPS formats.
+func GetCurrentRepo() (owner, repo string, err error) {
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to detect repo from git remote: %w", err)
+	}
+	url := strings.TrimSpace(string(out))
+
+	if m := gitSSHRemoteRE.FindStringSubmatch(url); len(m) == 3 {
+		debug.Log("detected repo from SSH remote", "owner", m[1], "repo", m[2])
+		return m[1], m[2], nil
+	}
+	if m := gitHTTPSRemoteRE.FindStringSubmatch(url); len(m) == 3 {
+		debug.Log("detected repo from HTTPS remote", "owner", m[1], "repo", m[2])
+		return m[1], m[2], nil
+	}
+
+	return "", "", fmt.Errorf("could not parse owner/repo from git remote URL: %q", url)
+}

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -19,14 +19,35 @@ var (
 // ParseRepoArg extracts owner and repo from a string in "owner/repo" or
 // "https://github.com/owner/repo" format. PR URLs and Actions run URLs are
 // rejected — this is only for repo-level arguments.
+//
+// All-underscore segments (e.g. "_", "__") are rejected even though the
+// regex character class allows underscores. This keeps "_" usable as the
+// NoOptDefVal sentinel for the --repo flag in main.go: a user typing
+// `gh-observer --repo _` gets a clean "invalid repo argument" error rather
+// than silently being treated as auto-detect or as a literal owner/repo of
+// "_". Embedded underscores (e.g. "my_org/my_repo") are still accepted.
 func ParseRepoArg(arg string) (owner, repo string, err error) {
 	if m := repoSlugPattern.FindStringSubmatch(arg); len(m) == 3 {
+		if isAllUnderscoreSegment(m[1]) || isAllUnderscoreSegment(m[2]) {
+			return "", "", fmt.Errorf("invalid repo argument: %q (expected \"owner/repo\" or \"https://github.com/owner/repo\")", arg)
+		}
 		return m[1], m[2], nil
 	}
 	if m := repoURLPattern.FindStringSubmatch(arg); len(m) == 3 {
+		if isAllUnderscoreSegment(m[1]) || isAllUnderscoreSegment(m[2]) {
+			return "", "", fmt.Errorf("invalid repo argument: %q (expected \"owner/repo\" or \"https://github.com/owner/repo\")", arg)
+		}
 		return m[1], m[2], nil
 	}
 	return "", "", fmt.Errorf("invalid repo argument: %q (expected \"owner/repo\" or \"https://github.com/owner/repo\")", arg)
+}
+
+// isAllUnderscoreSegment returns true for strings composed entirely of
+// underscores (e.g. "_", "__", "___"). Such strings are valid against the
+// slug regex but are not real GitHub owner/repo names, and "_" is used as
+// the --repo auto-detect sentinel in main.go.
+func isAllUnderscoreSegment(s string) bool {
+	return s != "" && strings.Trim(s, "_") == ""
 }
 
 // GetCurrentRepo detects the owner and repo from the current git remote.

--- a/internal/github/repo_graphql.go
+++ b/internal/github/repo_graphql.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/fini-net/gh-observer/internal/debug"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+// maxPRsPerQuery caps the number of open PRs fetched per repo query.
+// 50 matches GitHub's typical "first" page size for pullRequests and keeps
+// the batched query cost reasonable.
+const maxPRsPerQuery = 50
+
+// PRCheckData holds check run data for a single PR in repo mode.
+type PRCheckData struct {
+	Number         int
+	Title          string
+	CheckRuns      []CheckRunInfo
+	HeadCommitTime time.Time
+}
+
+// repoPRQuery fetches open PRs with their check rollup in a single query.
+// Reuses contextNode from graphql.go so contextNodesToCheckRuns works unchanged.
+type repoPRQuery struct {
+	Repository struct {
+		PullRequests struct {
+			Nodes []struct {
+				Number  int
+				Title   string
+				Commits struct {
+					Nodes []struct {
+						Commit struct {
+							PushedDate    githubv4.DateTime `graphql:"pushedDate"`
+							CommittedDate githubv4.DateTime `graphql:"committedDate"`
+							StatusCheckRollup struct {
+								Contexts struct {
+									Nodes    []contextNode
+									PageInfo struct {
+										HasNextPage bool
+										EndCursor   githubv4.String
+									}
+								} `graphql:"contexts(first: 100)"`
+							}
+						}
+					}
+				} `graphql:"commits(last: 1)"`
+			}
+		} `graphql:"pullRequests(first: $prLimit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC})"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+	RateLimit struct {
+		Remaining int
+	}
+}
+
+// FetchRepoCheckRunsGraphQL fetches check runs for all open PRs in a repo
+// using a single batched GraphQL query. Returns a map of PR number to PRCheckData
+// and the remaining rate limit.
+//
+// Note: each PR's status contexts are capped at 100 (no cursor pagination).
+// PRs with more than 100 status contexts will show an incomplete set; a future
+// enhancement can fall back to per-PR pagination for PRs that hit the cap.
+func FetchRepoCheckRunsGraphQL(ctx context.Context, token, owner, repo string) (map[int]PRCheckData, int, error) {
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(ctx, src)
+	client := githubv4.NewClient(httpClient)
+	return fetchRepoCheckRunsGraphQL(ctx, client, owner, repo)
+}
+
+func fetchRepoCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, repo string) (map[int]PRCheckData, int, error) {
+	var query repoPRQuery
+	variables := map[string]any{
+		"owner":   githubv4.String(owner),
+		"repo":    githubv4.String(repo),
+		"prLimit": githubv4.Int(maxPRsPerQuery),
+	}
+
+	err := client.Query(ctx, &query, variables)
+	if err != nil {
+		debug.Log("repo graphql query failed", "owner", owner, "repo", repo, "err", err)
+		return nil, 5000, err
+	}
+
+	debug.Log("repo graphql query success", "owner", owner, "repo", repo,
+		"pr_count", len(query.Repository.PullRequests.Nodes),
+		"rate_limit_remaining", query.RateLimit.Remaining)
+
+	rateLimitRemaining := query.RateLimit.Remaining
+
+	result := make(map[int]PRCheckData)
+	for _, pr := range query.Repository.PullRequests.Nodes {
+		if len(pr.Commits.Nodes) == 0 {
+			continue
+		}
+
+		commit := pr.Commits.Nodes[0].Commit
+		var headCommitTime time.Time
+		if !commit.PushedDate.IsZero() {
+			headCommitTime = commit.PushedDate.Time
+		} else if !commit.CommittedDate.IsZero() {
+			headCommitTime = commit.CommittedDate.Time
+		}
+
+		checkRuns := contextNodesToCheckRuns(commit.StatusCheckRollup.Contexts.Nodes)
+
+		if len(checkRuns) == 0 && headCommitTime.IsZero() {
+			continue
+		}
+
+		result[pr.Number] = PRCheckData{
+			Number:         pr.Number,
+			Title:          pr.Title,
+			CheckRuns:      checkRuns,
+			HeadCommitTime: headCommitTime,
+		}
+	}
+
+	return result, rateLimitRemaining, nil
+}

--- a/internal/github/repo_graphql.go
+++ b/internal/github/repo_graphql.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/fini-net/gh-observer/internal/debug"
@@ -26,8 +27,49 @@ type PRCheckData struct {
 	HeadCommitTime time.Time
 }
 
+// repoContextNode is the union type for StatusCheckRollup contexts in the
+// repo-mode query. It is a trimmed copy of contextNode from graphql.go that
+// OMITS the annotations(first: 5) field. Annotations are the single most
+// expensive part of the query (5 nodes × ~100 contexts × N PRs) and push the
+// query over GitHub's GraphQL "Resource limits for this query exceeded"
+// threshold on high-traffic repos like grafana/grafana at prLimit=10. Repo
+// mode is a persistent overview and never renders annotations (only single-PR
+// mode's renderErrorBox does), so dropping them here is safe and makes the
+// query 10/10 reliable instead of 7/10 borderline-504.
+type repoContextNode struct {
+	Typename        string `graphql:"__typename"`
+	CheckRunContext struct {
+		Name        string
+		Summary     string
+		Status      string
+		Conclusion  string
+		StartedAt   githubv4.DateTime
+		CompletedAt githubv4.DateTime
+		DetailsURL  string `graphql:"detailsUrl"`
+		CheckSuite  struct {
+			WorkflowRun struct {
+				DatabaseID BigInt `graphql:"databaseId"`
+				Workflow   struct {
+					DatabaseID BigInt `graphql:"databaseId"`
+					Name       string
+				}
+			}
+			App struct {
+				Name string
+				Slug string
+			}
+		}
+	} `graphql:"... on CheckRun"`
+	StatusContext struct {
+		Context     string
+		Description string
+		State       string
+		TargetURL   string `graphql:"targetUrl"`
+	} `graphql:"... on StatusContext"`
+}
+
 // repoPRQuery fetches open PRs with their check rollup in a single query.
-// Reuses contextNode from graphql.go so contextNodesToCheckRuns works unchanged.
+// Uses repoContextNode (no annotations) to stay under GitHub's query cost limit.
 type repoPRQuery struct {
 	Repository struct {
 		PullRequests struct {
@@ -41,7 +83,7 @@ type repoPRQuery struct {
 							CommittedDate githubv4.DateTime `graphql:"committedDate"`
 							StatusCheckRollup struct {
 								Contexts struct {
-									Nodes    []contextNode
+									Nodes    []repoContextNode
 									PageInfo struct {
 										HasNextPage bool
 										EndCursor   githubv4.String
@@ -66,6 +108,11 @@ type repoPRQuery struct {
 // Note: each PR's status contexts are capped at 100 (no cursor pagination).
 // PRs with more than 100 status contexts will show an incomplete set; a future
 // enhancement can fall back to per-PR pagination for PRs that hit the cap.
+//
+// The query deliberately omits the annotations(first: 5) field to stay under
+// GitHub's GraphQL query cost limit on high-traffic repos. Repo mode never
+// renders inline error annotations (only single-PR mode does), so CheckRunInfo
+// entries from this path have an empty Annotations slice.
 func FetchRepoCheckRunsGraphQL(ctx context.Context, token, owner, repo string) (map[int]PRCheckData, int, error) {
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(ctx, src)
@@ -107,7 +154,7 @@ func fetchRepoCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner
 			headCommitTime = commit.CommittedDate.Time
 		}
 
-		checkRuns := contextNodesToCheckRuns(commit.StatusCheckRollup.Contexts.Nodes)
+		checkRuns := repoContextNodesToCheckRuns(commit.StatusCheckRollup.Contexts.Nodes)
 
 		if len(checkRuns) == 0 && headCommitTime.IsZero() {
 			continue
@@ -122,4 +169,79 @@ func fetchRepoCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner
 	}
 
 	return result, rateLimitRemaining, nil
+}
+
+// repoContextNodesToCheckRuns converts repoContextNode slice to CheckRunInfo.
+// It is a trimmed copy of contextNodesToCheckRuns from graphql.go that always
+// produces an empty Annotations slice (the repo query does not fetch them).
+func repoContextNodesToCheckRuns(nodes []repoContextNode) []CheckRunInfo {
+	var checkRuns []CheckRunInfo
+
+	for _, node := range nodes {
+		if node.Typename == "StatusContext" {
+			statusContext := node.StatusContext
+			state := strings.ToLower(statusContext.State)
+
+			var status, conclusion string
+			switch state {
+			case "success":
+				status = "completed"
+				conclusion = "success"
+			case "error", "failure":
+				status = "completed"
+				conclusion = "failure"
+			case "pending":
+				status = "queued"
+				conclusion = ""
+			default:
+				status = "queued"
+				conclusion = ""
+			}
+
+			checkRuns = append(checkRuns, CheckRunInfo{
+				Name:       statusContext.Context,
+				Summary:    statusContext.Description,
+				Status:     status,
+				Conclusion: conclusion,
+				DetailsURL: statusContext.TargetURL,
+			})
+			continue
+		}
+
+		if node.Typename != "CheckRun" {
+			continue
+		}
+
+		checkRun := node.CheckRunContext
+		workflowName := checkRun.CheckSuite.WorkflowRun.Workflow.Name
+		appName := checkRun.CheckSuite.App.Name
+		workflowRunID := int64(checkRun.CheckSuite.WorkflowRun.DatabaseID)
+		workflowID := int64(checkRun.CheckSuite.WorkflowRun.Workflow.DatabaseID)
+
+		var startedAt, completedAt *time.Time
+		if !checkRun.StartedAt.IsZero() {
+			t := checkRun.StartedAt.Time
+			startedAt = &t
+		}
+		if !checkRun.CompletedAt.IsZero() {
+			t := checkRun.CompletedAt.Time
+			completedAt = &t
+		}
+
+		checkRuns = append(checkRuns, CheckRunInfo{
+			Name:          checkRun.Name,
+			WorkflowName:  workflowName,
+			AppName:       appName,
+			Summary:       checkRun.Summary,
+			Status:        strings.ToLower(checkRun.Status),
+			Conclusion:    strings.ToLower(checkRun.Conclusion),
+			StartedAt:     startedAt,
+			CompletedAt:   completedAt,
+			DetailsURL:    checkRun.DetailsURL,
+			WorkflowRunID: workflowRunID,
+			WorkflowID:    workflowID,
+		})
+	}
+
+	return checkRuns
 }

--- a/internal/github/repo_graphql.go
+++ b/internal/github/repo_graphql.go
@@ -10,9 +10,13 @@ import (
 )
 
 // maxPRsPerQuery caps the number of open PRs fetched per repo query.
-// 50 matches GitHub's typical "first" page size for pullRequests and keeps
-// the batched query cost reasonable.
-const maxPRsPerQuery = 50
+// GitHub's GraphQL server-side query timeout is ~10s. Fetching check rollups
+// (contexts(first: 100)) for each PR scales linearly: prLimit=50 504s on
+// high-traffic repos like grafana/grafana (137 workflows, thousands of open
+// PRs), while prLimit=10 returns in ~6s even for grafana. 10 most-recently-
+// updated PRs is a useful persistent overview; the fade-out window means
+// older completed checks disappear from the display soon anyway.
+const maxPRsPerQuery = 10
 
 // PRCheckData holds check run data for a single PR in repo mode.
 type PRCheckData struct {

--- a/internal/github/repo_graphql_test.go
+++ b/internal/github/repo_graphql_test.go
@@ -1,0 +1,227 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// makeRepoCheckRunNode builds a repoContextNode with a CheckRun typename and
+// the given fields. Mirrors makeCheckRunNode but for the repo-mode struct
+// (which has no Annotations field).
+func makeRepoCheckRunNode(name, status, conclusion, workflowName, appName string, startedAt, completedAt githubv4.DateTime, detailsURL string, workflowRunID, workflowID int64) repoContextNode {
+	return repoContextNode{
+		Typename: "CheckRun",
+		CheckRunContext: struct {
+			Name        string
+			Summary     string
+			Status      string
+			Conclusion  string
+			StartedAt   githubv4.DateTime
+			CompletedAt githubv4.DateTime
+			DetailsURL  string `graphql:"detailsUrl"`
+			CheckSuite  struct {
+				WorkflowRun struct {
+					DatabaseID BigInt `graphql:"databaseId"`
+					Workflow   struct {
+						DatabaseID BigInt `graphql:"databaseId"`
+						Name       string
+					}
+				}
+				App struct {
+					Name string
+					Slug string
+				}
+			}
+		}{
+			Name:        name,
+			Status:      status,
+			Conclusion:  conclusion,
+			StartedAt:   startedAt,
+			CompletedAt: completedAt,
+			DetailsURL:  detailsURL,
+			CheckSuite: struct {
+				WorkflowRun struct {
+					DatabaseID BigInt `graphql:"databaseId"`
+					Workflow   struct {
+						DatabaseID BigInt `graphql:"databaseId"`
+						Name       string
+					}
+				}
+				App struct {
+					Name string
+					Slug string
+				}
+			}{
+				WorkflowRun: struct {
+					DatabaseID BigInt `graphql:"databaseId"`
+					Workflow   struct {
+						DatabaseID BigInt `graphql:"databaseId"`
+						Name       string
+					}
+				}{
+					DatabaseID: BigInt(workflowRunID),
+					Workflow: struct {
+						DatabaseID BigInt `graphql:"databaseId"`
+						Name       string
+					}{
+						DatabaseID: BigInt(workflowID),
+						Name:       workflowName,
+					},
+				},
+				App: struct {
+					Name string
+					Slug string
+				}{
+					Name: appName,
+				},
+			},
+		},
+	}
+}
+
+func TestRepoContextNodesToCheckRuns(t *testing.T) {
+	startedAt := githubv4.DateTime{}
+	startedAt.Time = time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	completedAt := githubv4.DateTime{}
+	completedAt.Time = time.Date(2024, 1, 15, 10, 35, 0, 0, time.UTC)
+
+	tests := []struct {
+		name              string
+		nodes             []repoContextNode
+		wantLen           int
+		wantNames         []string
+		wantWorkflowNames []string
+		wantAppNames      []string
+		wantAnnotations   int // all entries should have this many annotations (always 0 for repo mode)
+	}{
+		{
+			name:  "empty nodes returns nil",
+			nodes: []repoContextNode{},
+			wantLen: 0,
+		},
+		{
+			name: "StatusContext success maps to completed/success",
+			nodes: []repoContextNode{
+				{
+					Typename: "StatusContext",
+					StatusContext: struct {
+						Context     string
+						Description string
+						State       string
+						TargetURL   string `graphql:"targetUrl"`
+					}{
+						Context:   "ci/travis",
+						State:     "success",
+						TargetURL: "https://travis-ci.org/owner/repo/builds/1",
+					},
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"ci/travis"},
+		},
+		{
+			name: "StatusContext pending maps to queued",
+			nodes: []repoContextNode{
+				{
+					Typename: "StatusContext",
+					StatusContext: struct {
+						Context     string
+						Description string
+						State       string
+						TargetURL   string `graphql:"targetUrl"`
+					}{
+						Context: "ci/waiting",
+						State:   "pending",
+					},
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"ci/waiting"},
+		},
+		{
+			name: "CheckRun with workflow name and timestamps",
+			nodes: []repoContextNode{
+				makeRepoCheckRunNode("lint", "COMPLETED", "SUCCESS", "CI", "GitHub Actions", startedAt, completedAt, "https://github.com/owner/repo/actions/runs/100/job/200", 100, 10),
+			},
+			wantLen:           1,
+			wantNames:         []string{"lint"},
+			wantWorkflowNames: []string{"CI"},
+			wantAppNames:      []string{"GitHub Actions"},
+		},
+		{
+			name: "CheckRun without workflow name",
+			nodes: []repoContextNode{
+				makeRepoCheckRunNode("legacy-check", "COMPLETED", "FAILURE", "", "", githubv4.DateTime{}, githubv4.DateTime{}, "", 0, 0),
+			},
+			wantLen:           1,
+			wantNames:         []string{"legacy-check"},
+			wantWorkflowNames: []string{""},
+		},
+		{
+			name: "unknown typename is skipped",
+			nodes: []repoContextNode{
+				{Typename: "SomeOtherType"},
+				makeRepoCheckRunNode("valid-check", "IN_PROGRESS", "", "", "", githubv4.DateTime{}, githubv4.DateTime{}, "", 0, 0),
+			},
+			wantLen:   1,
+			wantNames: []string{"valid-check"},
+		},
+		{
+			name: "mixed StatusContext and CheckRun nodes",
+			nodes: []repoContextNode{
+				{
+					Typename: "StatusContext",
+					StatusContext: struct {
+						Context     string
+						Description string
+						State       string
+						TargetURL   string `graphql:"targetUrl"`
+					}{
+						Context: "ci/travis",
+						State:   "success",
+					},
+				},
+				makeRepoCheckRunNode("test", "QUEUED", "", "", "", githubv4.DateTime{}, githubv4.DateTime{}, "", 0, 0),
+			},
+			wantLen:   2,
+			wantNames: []string{"ci/travis", "test"},
+		},
+		{
+			name: "CheckRun with zero timestamps produces nil time",
+			nodes: []repoContextNode{
+				makeRepoCheckRunNode("build", "QUEUED", "", "CI", "", githubv4.DateTime{}, githubv4.DateTime{}, "", 0, 0),
+			},
+			wantLen:   1,
+			wantNames: []string{"build"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runs := repoContextNodesToCheckRuns(tt.nodes)
+
+			if len(runs) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(runs), tt.wantLen)
+			}
+
+			for i, run := range runs {
+				if i < len(tt.wantNames) && run.Name != tt.wantNames[i] {
+					t.Errorf("Name[%d] = %q, want %q", i, run.Name, tt.wantNames[i])
+				}
+				if i < len(tt.wantWorkflowNames) && run.WorkflowName != tt.wantWorkflowNames[i] {
+					t.Errorf("WorkflowName[%d] = %q, want %q", i, run.WorkflowName, tt.wantWorkflowNames[i])
+				}
+				if i < len(tt.wantAppNames) && run.AppName != tt.wantAppNames[i] {
+					t.Errorf("AppName[%d] = %q, want %q", i, run.AppName, tt.wantAppNames[i])
+				}
+				// Repo mode never fetches annotations; verify always empty.
+				if len(run.Annotations) != 0 {
+					t.Errorf("Annotations[%d] = %v, want empty (repo mode drops annotations)", i, run.Annotations)
+				}
+			}
+		})
+	}
+}

--- a/internal/github/repo_runs.go
+++ b/internal/github/repo_runs.go
@@ -1,0 +1,162 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fini-net/gh-observer/internal/debug"
+	"github.com/google/go-github/v88/github"
+)
+
+// BranchRunData holds a standalone (non-PR) workflow run and its jobs.
+// Used by repo mode to show post-merge, scheduled, and workflow_dispatch runs
+// grouped by branch separately from PR check rolls.
+type BranchRunData struct {
+	RunID        int64
+	DisplayTitle string
+	HeadBranch   string
+	Event        string
+	WorkflowName string
+	WorkflowID   int64
+	Status       string
+	Conclusion   string
+	CreatedAt    time.Time
+	RunStartedAt time.Time
+	Jobs         []CheckRunInfo
+}
+
+// FetchRepoWorkflowRuns lists standalone (non-PR) workflow runs on a repo that
+// are either currently active or completed within fadeWindow. It issues two
+// ListRepositoryWorkflowRuns calls (in_progress, then recently-created) with
+// ExcludePullRequests set so PR-triggered runs are not double-counted against
+// the PR GraphQL query.
+//
+// Returns the deduplicated run list and the minimum rate-limit remaining observed.
+func FetchRepoWorkflowRuns(ctx context.Context, client *github.Client, owner, repo string, fadeWindow time.Duration) ([]BranchRunData, int, error) {
+	rateLimitRemaining := 5000
+
+	inProgress := &github.ListWorkflowRunsOptions{
+		ExcludePullRequests: true,
+		Status:              "in_progress",
+		ListOptions:         github.ListOptions{PerPage: 100},
+	}
+	activeRuns, rl1, err := fetchRepoRunPage(ctx, client, owner, repo, inProgress)
+	if err != nil {
+		return nil, rateLimitRemaining, err
+	}
+	if rl1 < rateLimitRemaining {
+		rateLimitRemaining = rl1
+	}
+
+	// Recently completed: filter by creation date to bound the result set.
+	recent := &github.ListWorkflowRunsOptions{
+		ExcludePullRequests: true,
+		Created:              ">=" + time.Now().Add(-fadeWindow).Format(time.DateOnly),
+		ListOptions:         github.ListOptions{PerPage: 100},
+	}
+	completedRuns, rl2, err := fetchRepoRunPage(ctx, client, owner, repo, recent)
+	if err != nil {
+		debug.Log("failed to fetch completed repo runs", "owner", owner, "repo", repo, "err", err)
+		return activeRuns, rateLimitRemaining, nil
+	}
+	if rl2 < rateLimitRemaining {
+		rateLimitRemaining = rl2
+	}
+
+	seen := make(map[int64]bool)
+	var result []BranchRunData
+	for _, r := range activeRuns {
+		if !seen[r.RunID] {
+			seen[r.RunID] = true
+			result = append(result, r)
+		}
+	}
+	for _, r := range completedRuns {
+		if !seen[r.RunID] {
+			seen[r.RunID] = true
+			result = append(result, r)
+		}
+	}
+
+	debug.Log("fetched repo workflow runs", "owner", owner, "repo", repo,
+		"active", len(activeRuns), "recent", len(completedRuns),
+		"total", len(result), "rate_limit_remaining", rateLimitRemaining)
+
+	return result, rateLimitRemaining, nil
+}
+
+func fetchRepoRunPage(ctx context.Context, client *github.Client, owner, repo string, opts *github.ListWorkflowRunsOptions) ([]BranchRunData, int, error) {
+	var allRuns []BranchRunData
+	rateLimitRemaining := 5000
+
+	for {
+		runs, resp, err := client.Actions.ListRepositoryWorkflowRuns(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, rateLimitRemaining, fmt.Errorf("failed to list repo workflow runs: %w", err)
+		}
+		if resp != nil {
+			rateLimitRemaining = resp.Rate.Remaining
+		}
+		for _, run := range runs.WorkflowRuns {
+			allRuns = append(allRuns, convertBranchRun(run))
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allRuns, rateLimitRemaining, nil
+}
+
+func convertBranchRun(run *github.WorkflowRun) BranchRunData {
+	data := BranchRunData{
+		RunID:      run.GetID(),
+		HeadBranch: run.GetHeadBranch(),
+		Event:      run.GetEvent(),
+		WorkflowID: run.GetWorkflowID(),
+		Status:     strings.ToLower(run.GetStatus()),
+		Conclusion: strings.ToLower(run.GetConclusion()),
+	}
+	if run.DisplayTitle != nil && *run.DisplayTitle != "" {
+		data.DisplayTitle = *run.DisplayTitle
+	} else if run.Name != nil {
+		data.DisplayTitle = *run.Name
+	}
+	if run.CreatedAt != nil {
+		data.CreatedAt = run.CreatedAt.Time
+	}
+	if run.RunStartedAt != nil {
+		data.RunStartedAt = run.RunStartedAt.Time
+	}
+	return data
+}
+
+// EnrichRepoRunsWithJobs fetches jobs for each run via FetchRunJobs and adapts
+// them to CheckRunInfo so the TUI can reuse display helpers. WorkflowName is
+// copied from the first job (GitHub populates it on WorkflowJob).
+//
+// Failures on individual runs are non-fatal: the run is kept with an empty
+// Jobs slice so the TUI can still render its header.
+func EnrichRepoRunsWithJobs(ctx context.Context, client *github.Client, owner, repo string, runs []BranchRunData) ([]BranchRunData, int, error) {
+	rateLimitRemaining := 5000
+	for i := range runs {
+		jobs, rl, err := FetchRunJobs(ctx, client, owner, repo, runs[i].RunID)
+		if err != nil {
+			debug.Log("failed to fetch jobs for repo run", "run_id", runs[i].RunID, "err", err)
+			continue
+		}
+		if rl < rateLimitRemaining {
+			rateLimitRemaining = rl
+		}
+
+		checkRuns := WorkflowJobInfoToCheckRuns(jobs)
+		runs[i].Jobs = checkRuns
+
+		if len(checkRuns) > 0 && checkRuns[0].WorkflowName != "" {
+			runs[i].WorkflowName = checkRuns[0].WorkflowName
+		}
+	}
+	return runs, rateLimitRemaining, nil
+}

--- a/internal/github/repo_runs.go
+++ b/internal/github/repo_runs.go
@@ -51,9 +51,12 @@ func FetchRepoWorkflowRuns(ctx context.Context, client *github.Client, owner, re
 	}
 
 	// Recently completed: filter by creation date to bound the result set.
+	// RFC3339 (not time.DateOnly) so a 30m fade window queries the last 30
+	// minutes, not the whole calendar day — the date-only form made the
+	// server-side scan ~10x more expensive and triggered 504s on busy repos.
 	recent := &github.ListWorkflowRunsOptions{
 		ExcludePullRequests: true,
-		Created:              ">=" + time.Now().Add(-fadeWindow).Format(time.DateOnly),
+		Created:             ">=" + time.Now().Add(-fadeWindow).Format(time.RFC3339),
 		ListOptions:         github.ListOptions{PerPage: 100},
 	}
 	completedRuns, rl2, err := fetchRepoRunPage(ctx, client, owner, repo, recent)
@@ -87,26 +90,29 @@ func FetchRepoWorkflowRuns(ctx context.Context, client *github.Client, owner, re
 	return result, rateLimitRemaining, nil
 }
 
+// fetchRepoRunPage fetches a single page of workflow runs. It deliberately does
+// NOT follow pagination: paginating through hundreds of recent runs on a
+// high-traffic repo (e.g. grafana/grafana with ~400 completions/30m) takes
+// multiple round-trips that can exceed GitHub's ~10s server-side query timeout
+// and return 504 Gateway Timeout. The first 100 runs is enough for the
+// persistent repo-watch view — the fade-out window means older runs would
+// disappear from the display soon anyway.
 func fetchRepoRunPage(ctx context.Context, client *github.Client, owner, repo string, opts *github.ListWorkflowRunsOptions) ([]BranchRunData, int, error) {
-	var allRuns []BranchRunData
 	rateLimitRemaining := 5000
 
-	for {
-		runs, resp, err := client.Actions.ListRepositoryWorkflowRuns(ctx, owner, repo, opts)
-		if err != nil {
-			return nil, rateLimitRemaining, fmt.Errorf("failed to list repo workflow runs: %w", err)
-		}
-		if resp != nil {
-			rateLimitRemaining = resp.Rate.Remaining
-		}
-		for _, run := range runs.WorkflowRuns {
-			allRuns = append(allRuns, convertBranchRun(run))
-		}
-		if resp == nil || resp.NextPage == 0 {
-			break
-		}
-		opts.Page = resp.NextPage
+	runs, resp, err := client.Actions.ListRepositoryWorkflowRuns(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, rateLimitRemaining, fmt.Errorf("failed to list repo workflow runs: %w", err)
 	}
+	if resp != nil {
+		rateLimitRemaining = resp.Rate.Remaining
+	}
+
+	var allRuns []BranchRunData
+	for _, run := range runs.WorkflowRuns {
+		allRuns = append(allRuns, convertBranchRun(run))
+	}
+
 	return allRuns, rateLimitRemaining, nil
 }
 

--- a/internal/github/repo_runs_test.go
+++ b/internal/github/repo_runs_test.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v88/github"
+)
+
+func TestFetchRepoRunPageSinglePage(t *testing.T) {
+	// Serve 3 pages of runs (100 + 50 + 1) and verify fetchRepoRunPage only
+	// makes ONE request and returns only the first page's runs — proving it
+	// does not follow NextPage. This guards against the 504-causing pagination
+	// over hundreds of recent runs on high-traffic repos.
+	var requestCount atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		var runs []map[string]any
+		count := 100
+		if n > 1 {
+			// If the code paginates, return a different (smaller) page so we
+			// can detect that the caller followed NextPage.
+			count = 50
+		}
+		for i := 0; i < count; i++ {
+			id := int64(n)*1000 + int64(i)
+			runs = append(runs, map[string]any{
+				"id":           id,
+				"name":         "run",
+				"head_branch":  "main",
+				"head_sha":     "abc",
+				"event":        "push",
+				"status":       "completed",
+				"conclusion":   "success",
+				"workflow_id":  42,
+				"created_at":   "2026-06-18T00:00:00Z",
+				"updated_at":   "2026-06-18T00:01:00Z",
+				"run_started_at": "2026-06-18T00:00:00Z",
+			})
+		}
+
+		body := map[string]any{
+			"total_count":   151,
+			"workflow_runs": runs,
+		}
+		// Always claim there's a next page (page 2 exists). If the code
+		// follows NextPage it will call back and requestCount will hit 2.
+		w.Header().Set("Link", `<https://api.github.com/repos/owner/repo/actions/runs?page=2>; rel="next", <https://api.github.com/repos/owner/repo/actions/runs?page=2>; rel="last"`)
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client, _ := github.NewClient(github.WithURLs(ptrTo(server.URL+"/"), ptrTo(server.URL+"/")))
+
+	opts := &github.ListWorkflowRunsOptions{
+		ExcludePullRequests: true,
+		ListOptions:         github.ListOptions{PerPage: 100},
+	}
+
+	runs, _, err := fetchRepoRunPage(context.Background(), client, "owner", "repo", opts)
+	if err != nil {
+		t.Fatalf("fetchRepoRunPage error: %v", err)
+	}
+
+	if got := requestCount.Load(); got != 1 {
+		t.Errorf("request count = %d, want 1 (must not paginate)", got)
+	}
+	if len(runs) != 100 {
+		t.Errorf("runs returned = %d, want 100 (first page only)", len(runs))
+	}
+}
+
+func TestFetchRepoWorkflowRunsCreatedFilterFormat(t *testing.T) {
+	// Verify the Created: date-range filter uses an RFC3339 timestamp (with
+	// time component), not time.DateOnly (date only). The date-only form made
+	// a 30-minute fade window query the whole calendar day server-side, which
+	// returned ~10x more runs and triggered 504s on busy repos.
+	var capturedCreated string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		capturedCreated = r.URL.Query().Get("created")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":   0,
+			"workflow_runs": []any{},
+		})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client, _ := github.NewClient(github.WithURLs(ptrTo(server.URL+"/"), ptrTo(server.URL+"/")))
+
+	_, _, err := FetchRepoWorkflowRuns(context.Background(), client, "owner", "repo", 30*time.Minute)
+	if err != nil {
+		t.Fatalf("FetchRepoWorkflowRuns error: %v", err)
+	}
+
+	if capturedCreated == "" {
+		t.Fatal("created query param not sent")
+	}
+	// RFC3339 contains a 'T' separator and 'Z' (or offset). DateOnly would be
+	// bare "YYYY-MM-DD". Assert we see the time component.
+	if len(capturedCreated) < len(">=2026-06-18T00:00:00Z") {
+		t.Errorf("created filter = %q, want RFC3339 timestamp (with time), got date-only?", capturedCreated)
+	}
+	if capturedCreated[:2] != ">=" {
+		t.Errorf("created filter = %q, want \">=\" prefix", capturedCreated)
+	}
+	// Strip the ">=" prefix and verify it parses as RFC3339.
+	tsStr := capturedCreated[2:]
+	if _, err := time.Parse(time.RFC3339, tsStr); err != nil {
+		t.Errorf("created filter timestamp %q is not valid RFC3339: %v", tsStr, err)
+	}
+}

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -42,6 +42,17 @@ func TestParseRepoArg(t *testing.T) {
 			wantRepo:  "repo",
 		},
 		{
+			// Embedded underscores are allowed in GitHub owner/repo names.
+			input:     "my_org/my_repo",
+			wantOwner: "my_org",
+			wantRepo:  "my_repo",
+		},
+		{
+			input:     "https://github.com/my_org/my_repo",
+			wantOwner: "my_org",
+			wantRepo:  "my_repo",
+		},
+		{
 			input:   "",
 			wantErr: true,
 		},
@@ -63,6 +74,38 @@ func TestParseRepoArg(t *testing.T) {
 		},
 		{
 			input:   "https://github.com/owner/repo/actions/runs/456",
+			wantErr: true,
+		},
+		// All-underscore segments are rejected so the --repo auto-detect
+		// sentinel "_" in main.go can't collide with a literal owner/repo.
+		// These should error rather than being treated as auto-detect or as
+		// a real repo named "_".
+		{
+			input:   "_",
+			wantErr: true,
+		},
+		{
+			input:   "__",
+			wantErr: true,
+		},
+		{
+			input:   "_/repo",
+			wantErr: true,
+		},
+		{
+			input:   "owner/_",
+			wantErr: true,
+		},
+		{
+			input:   "__/__",
+			wantErr: true,
+		},
+		{
+			input:   "https://github.com/_/repo",
+			wantErr: true,
+		},
+		{
+			input:   "https://github.com/owner/_",
 			wantErr: true,
 		},
 	}

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestParseRepoArg(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			input:     "owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			input:     "https://github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			input:     "https://github.com/owner/repo.name",
+			wantOwner: "owner",
+			wantRepo:  "repo.name",
+		},
+		{
+			input:     "http://github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			input:     "https://github.com/owner/repo.git",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			input:     "https://github.com/owner/repo.git/",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+		{
+			input:   "owner",
+			wantErr: true,
+		},
+		{
+			input:   "owner/repo/extra",
+			wantErr: true,
+		},
+		{
+			input:   "https://gitlab.com/owner/repo",
+			wantErr: true,
+		},
+		{
+			input:   "https://github.com/owner/repo/pull/123",
+			wantErr: true,
+		},
+		{
+			input:   "https://github.com/owner/repo/actions/runs/456",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			owner, repo, err := ParseRepoArg(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRepoArg(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("ParseRepoArg(%q) owner = %q, want %q", tt.input, owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("ParseRepoArg(%q) repo = %q, want %q", tt.input, repo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -6,9 +6,9 @@ const (
 	slowJobThreshold     = 2 * time.Minute
 	verySlowJobThreshold = 3 * time.Minute
 
-	rateBackoffThreshold  = 10
-	rateWarningThreshold  = 500
-	minRateLimitForFetch   = 100
+	rateBackoffThreshold = 10
+	rateWarningThreshold = 500
+	minRateLimitForFetch = 100
 
 	historyFetchDelay = 10 * time.Second
 

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -6,8 +6,9 @@ const (
 	slowJobThreshold     = 2 * time.Minute
 	verySlowJobThreshold = 3 * time.Minute
 
-	rateBackoffThreshold = 10
-	minRateLimitForFetch = 100
+	rateBackoffThreshold  = 10
+	rateWarningThreshold  = 500
+	minRateLimitForFetch   = 100
 
 	historyFetchDelay = 10 * time.Second
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -27,6 +27,11 @@ type Model struct {
 
 	// Rate limiting
 	rateLimitRemaining int
+	// fetchReceived is true after the first successful API response that
+	// populated rateLimitRemaining. Before that, rateLimitRemaining is the
+	// Go zero value (0) and the view must not render a misleading
+	// "[Rate limit: 0 remaining]" indicator or trigger backoff.
+	fetchReceived bool
 
 	// UI state
 	spinner         spinner.Model

--- a/internal/tui/repomodel.go
+++ b/internal/tui/repomodel.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"charm.land/bubbles/v2/spinner"
+	ghclient "github.com/fini-net/gh-observer/internal/github"
+)
+
+// PRViewData is the per-PR view state held by RepoModel after fade-out filtering.
+type PRViewData struct {
+	Title          string
+	CheckRuns      []ghclient.CheckRunInfo
+	HeadCommitTime time.Time
+}
+
+// RepoModel holds the application state for persistent repo watching.
+// It tracks both PR-associated checks (via the batched GraphQL query) and
+// standalone non-PR workflow runs (via REST), applying fade-out to completed
+// checks and runs so the view stays focused on what's active.
+type RepoModel struct {
+	ctx   context.Context
+	token string
+	owner string
+	repo  string
+
+	// PR data after fade-out filtering: PR number -> view data.
+	prs map[int]PRViewData
+
+	// Standalone (non-PR) workflow runs after fade-out filtering.
+	standaloneRuns []ghclient.BranchRunData
+
+	// Rate limiting
+	rateLimitRemaining int
+
+	// UI state
+	spinner         spinner.Model
+	startTime       time.Time
+	lastUpdate      time.Time
+	refreshInterval time.Duration
+	styles          Styles
+
+	// Fade-out windows for completed checks/runs.
+	fadeSuccess time.Duration
+	fadeFailure time.Duration
+
+	// Exit tracking. Repo mode is persistent: exitCode stays 0 and we only
+	// quit on q/ctrl+c. The field exists for symmetry with Model/RunModel.
+	exitCode int
+	quitting bool
+
+	// Error state (non-fatal; surfaced in the view)
+	err error
+
+	// Feature flags
+	enableLinks bool
+}
+
+// NewRepoModel creates a new persistent repo-watch TUI model.
+func NewRepoModel(
+	ctx context.Context,
+	token string,
+	owner, repo string,
+	refreshInterval time.Duration,
+	styles Styles,
+	enableLinks bool,
+	fadeSuccess, fadeFailure time.Duration,
+) RepoModel {
+	s := spinner.New(spinner.WithSpinner(spinner.Dot))
+
+	return RepoModel{
+		ctx:             ctx,
+		token:           token,
+		owner:           owner,
+		repo:            repo,
+		prs:             make(map[int]PRViewData),
+		spinner:         s,
+		startTime:       time.Now(),
+		lastUpdate:      time.Now(),
+		refreshInterval: refreshInterval,
+		styles:          styles,
+		enableLinks:     enableLinks,
+		fadeSuccess:     fadeSuccess,
+		fadeFailure:     fadeFailure,
+	}
+}
+
+// ExitCode returns the exit code for the program. Repo mode is persistent and
+// only exits on user quit, so this is always 0.
+func (m RepoModel) ExitCode() int {
+	return m.exitCode
+}
+
+// sortedPRNumbers returns PR numbers in ascending order for stable rendering.
+func (m RepoModel) sortedPRNumbers() []int {
+	nums := make([]int, 0, len(m.prs))
+	for n := range m.prs {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+	return nums
+}
+
+// fadeWindow returns the larger of the two fade durations, used to bound the
+// "recently completed" REST query window for standalone runs.
+func (m RepoModel) fadeWindow() time.Duration {
+	if m.fadeFailure > m.fadeSuccess {
+		return m.fadeFailure
+	}
+	return m.fadeSuccess
+}

--- a/internal/tui/repomodel.go
+++ b/internal/tui/repomodel.go
@@ -51,8 +51,13 @@ type RepoModel struct {
 	exitCode int
 	quitting bool
 
-	// Error state (non-fatal; surfaced in the view)
-	err error
+	// Non-fatal fetch error tracking. Transient errors (e.g. 504 Gateway
+	// Timeout) are surfaced as a status line without clearing the last good
+	// state, so a persistent watcher keeps showing stale data + an error
+	// indicator and recovers automatically when the API returns.
+	fetchErr       error
+	fetchErrAt     time.Time
+	fetchReceived  bool
 
 	// Feature flags
 	enableLinks bool

--- a/internal/tui/repomodel.go
+++ b/internal/tui/repomodel.go
@@ -51,13 +51,15 @@ type RepoModel struct {
 	exitCode int
 	quitting bool
 
-	// Non-fatal fetch error tracking. Transient errors (e.g. 504 Gateway
-	// Timeout) are surfaced as a status line without clearing the last good
-	// state, so a persistent watcher keeps showing stale data + an error
-	// indicator and recovers automatically when the API returns.
-	fetchErr       error
-	fetchErrAt     time.Time
-	fetchReceived  bool
+	// Non-fatal fetch error tracking, split per source. The GraphQL PR
+	// checks fetch and the REST standalone-runs fetch run independently,
+	// so a success from one source must not clear an ongoing error from
+	// the other. The view renders whichever source's error is most recent.
+	fetchErrChecks   error
+	fetchErrChecksAt time.Time
+	fetchErrRuns     error
+	fetchErrRunsAt   time.Time
+	fetchReceived    bool
 
 	// Feature flags
 	enableLinks bool

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -1,0 +1,234 @@
+package tui
+
+import (
+	"context"
+	"time"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"github.com/fini-net/gh-observer/internal/debug"
+	ghclient "github.com/fini-net/gh-observer/internal/github"
+	"github.com/google/go-github/v88/github"
+)
+
+// RepoTickMsg is sent on each repo-mode poll interval.
+type RepoTickMsg time.Time
+
+// RepoChecksUpdateMsg carries PR check data from the batched GraphQL query.
+type RepoChecksUpdateMsg struct {
+	PRData             map[int]ghclient.PRCheckData
+	RateLimitRemaining int
+	Err                error
+}
+
+// RepoRunsUpdateMsg carries standalone (non-PR) workflow runs from REST.
+type RepoRunsUpdateMsg struct {
+	Runs               []ghclient.BranchRunData
+	RateLimitRemaining int
+	Err                error
+}
+
+// Init kicks off the spinner, the first PR fetch, the first standalone-runs
+// fetch, and the tick that drives subsequent polls.
+func (m RepoModel) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		fetchRepoCheckRuns(m.ctx, m.token, m.owner, m.repo),
+		fetchRepoRuns(m.ctx, m.token, m.owner, m.repo, m.fadeWindow()),
+		repoTick(m.refreshInterval),
+	)
+}
+
+// Update dispatches messages to the appropriate handlers.
+func (m RepoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		}
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case RepoTickMsg:
+		// Rate-limit backoff: triple the interval when quota is critically low.
+		if m.rateLimitRemaining < rateBackoffThreshold {
+			debug.Log("rate limit backoff (repo)", "remaining", m.rateLimitRemaining, "threshold", rateBackoffThreshold)
+			return m, repoTick(m.refreshInterval * 3)
+		}
+		cmds := []tea.Cmd{
+			fetchRepoCheckRuns(m.ctx, m.token, m.owner, m.repo),
+			fetchRepoRuns(m.ctx, m.token, m.owner, m.repo, m.fadeWindow()),
+			repoTick(m.refreshInterval),
+		}
+		return m, tea.Batch(cmds...)
+
+	case RepoChecksUpdateMsg:
+		return m.handleRepoChecksUpdate(msg)
+
+	case RepoRunsUpdateMsg:
+		return m.handleRepoRunsUpdate(msg)
+	}
+
+	return m, nil
+}
+
+// handleRepoChecksUpdate applies fade-out filtering to PR checks and stores
+// the surviving PRs in m.prs. A PR stays visible while it has at least one
+// active (in_progress/queued) check, or a completed check whose CompletedAt
+// is within the configured fade window (fadeSuccess or fadeFailure).
+func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		m.err = msg.Err
+		return m, nil
+	}
+
+	m.rateLimitRemaining = msg.RateLimitRemaining
+	m.lastUpdate = time.Now()
+	m.err = nil
+
+	now := time.Now()
+	activePRs := make(map[int]PRViewData)
+
+	for prNum, prData := range msg.PRData {
+		checkRuns := prData.CheckRuns
+		SortCheckRuns(checkRuns)
+
+		var visible []ghclient.CheckRunInfo
+		for _, cr := range checkRuns {
+			if cr.Status == "in_progress" || cr.Status == "queued" || cr.Status == "waiting" {
+				visible = append(visible, cr)
+				continue
+			}
+			if cr.Status != "completed" {
+				continue
+			}
+			fadeTimeout := m.fadeSuccess
+			if ghclient.FailureConclusion(cr.Conclusion) {
+				fadeTimeout = m.fadeFailure
+			}
+			if cr.CompletedAt != nil && now.Sub(*cr.CompletedAt) < fadeTimeout {
+				visible = append(visible, cr)
+			}
+		}
+
+		if len(visible) == 0 {
+			continue
+		}
+		activePRs[prNum] = PRViewData{
+			Title:          prData.Title,
+			CheckRuns:      visible,
+			HeadCommitTime: prData.HeadCommitTime,
+		}
+	}
+
+	m.prs = activePRs
+
+	debug.Log("repo checks update", "total_prs", len(msg.PRData), "active_prs", len(activePRs),
+		"rate_limit_remaining", msg.RateLimitRemaining)
+
+	return m, nil
+}
+
+// handleRepoRunsUpdate applies the same fade-out logic to standalone runs and
+// stores the survivors in m.standaloneRuns. Active runs are always kept;
+// completed runs are kept if RunStartedAt is within the fade window.
+func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		debug.Log("repo runs fetch error", "err", msg.Err)
+		return m, nil
+	}
+
+	if msg.RateLimitRemaining < m.rateLimitRemaining {
+		m.rateLimitRemaining = msg.RateLimitRemaining
+	}
+	m.lastUpdate = time.Now()
+
+	now := time.Now()
+	var visible []ghclient.BranchRunData
+	for _, run := range msg.Runs {
+		if isActiveBranchRun(run.Status) {
+			visible = append(visible, run)
+			continue
+		}
+		if run.Status != "completed" {
+			continue
+		}
+		fadeTimeout := m.fadeSuccess
+		if ghclient.FailureConclusion(run.Conclusion) {
+			fadeTimeout = m.fadeFailure
+		}
+		if !run.RunStartedAt.IsZero() && now.Sub(run.RunStartedAt) < fadeTimeout {
+			visible = append(visible, run)
+		}
+	}
+
+	m.standaloneRuns = visible
+
+	debug.Log("repo runs update", "total", len(msg.Runs), "visible", len(visible),
+		"rate_limit_remaining", msg.RateLimitRemaining)
+
+	return m, nil
+}
+
+// isActiveBranchRun returns true for statuses that should always be shown.
+func isActiveBranchRun(status string) bool {
+	switch status {
+	case "in_progress", "queued", "waiting", "pending":
+		return true
+	}
+	return false
+}
+
+// repoTick schedules the next RepoTickMsg after d.
+func repoTick(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(t time.Time) tea.Msg {
+		return RepoTickMsg(t)
+	})
+}
+
+// fetchRepoCheckRuns issues the batched GraphQL query for all open PRs.
+func fetchRepoCheckRuns(ctx context.Context, token, owner, repo string) tea.Cmd {
+	return func() tea.Msg {
+		prData, rateLimit, err := ghclient.FetchRepoCheckRunsGraphQL(ctx, token, owner, repo)
+		return RepoChecksUpdateMsg{
+			PRData:             prData,
+			RateLimitRemaining: rateLimit,
+			Err:                err,
+		}
+	}
+}
+
+// fetchRepoRuns fetches standalone (non-PR) workflow runs and enriches them
+// with per-run jobs in a single command. Job enrichment failure is non-fatal:
+// runs are still returned with empty Jobs so their headers can render.
+func fetchRepoRuns(ctx context.Context, token, owner, repo string, fadeWindow time.Duration) tea.Cmd {
+	return func() tea.Msg {
+		client, err := github.NewClient(github.WithAuthToken(token))
+		if err != nil {
+			return RepoRunsUpdateMsg{Err: err}
+		}
+
+		runs, rateLimit, err := ghclient.FetchRepoWorkflowRuns(ctx, client, owner, repo, fadeWindow)
+		if err != nil {
+			return RepoRunsUpdateMsg{Err: err}
+		}
+
+		enriched, rl2, err := ghclient.EnrichRepoRunsWithJobs(ctx, client, owner, repo, runs)
+		if err != nil {
+			debug.Log("enrich repo runs error", "err", err)
+		}
+		if rl2 < rateLimit {
+			rateLimit = rl2
+		}
+
+		return RepoRunsUpdateMsg{
+			Runs:               enriched,
+			RateLimitRemaining: rateLimit,
+		}
+	}
+}

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -81,15 +81,24 @@ func (m RepoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // the surviving PRs in m.prs. A PR stays visible while it has at least one
 // active (in_progress/queued) check, or a completed check whose CompletedAt
 // is within the configured fade window (fadeSuccess or fadeFailure).
+//
+// Transient fetch errors (e.g. 504 Gateway Timeout) are non-fatal: the last
+// good m.prs is preserved on screen, the error is surfaced via m.fetchErr for
+// the view to render as a status line, and polling continues. The error
+// clears automatically on the next successful fetch.
 func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
-		m.err = msg.Err
+		m.fetchErr = msg.Err
+		m.fetchErrAt = time.Now()
+		debug.Log("repo checks fetch error", "err", msg.Err)
 		return m, nil
 	}
 
 	m.rateLimitRemaining = msg.RateLimitRemaining
 	m.lastUpdate = time.Now()
-	m.err = nil
+	m.fetchErr = nil
+	m.fetchErrAt = time.Time{}
+	m.fetchReceived = true
 
 	now := time.Now()
 	activePRs := make(map[int]PRViewData)
@@ -137,8 +146,13 @@ func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, 
 // handleRepoRunsUpdate applies the same fade-out logic to standalone runs and
 // stores the survivors in m.standaloneRuns. Active runs are always kept;
 // completed runs are kept if RunStartedAt is within the fade window.
+//
+// Transient fetch errors are non-fatal: the last good m.standaloneRuns is
+// preserved, the error is surfaced via m.fetchErr, and polling continues.
 func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
+		m.fetchErr = msg.Err
+		m.fetchErrAt = time.Now()
 		debug.Log("repo runs fetch error", "err", msg.Err)
 		return m, nil
 	}
@@ -147,6 +161,9 @@ func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.
 		m.rateLimitRemaining = msg.RateLimitRemaining
 	}
 	m.lastUpdate = time.Now()
+	m.fetchErr = nil
+	m.fetchErrAt = time.Time{}
+	m.fetchReceived = true
 
 	now := time.Now()
 	var visible []ghclient.BranchRunData

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -86,21 +86,30 @@ func (m RepoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // is within the configured fade window (fadeSuccess or fadeFailure).
 //
 // Transient fetch errors (e.g. 504 Gateway Timeout) are non-fatal: the last
-// good m.prs is preserved on screen, the error is surfaced via m.fetchErr for
-// the view to render as a status line, and polling continues. The error
-// clears automatically on the next successful fetch.
+// good m.prs is preserved on screen, the error is surfaced via
+// m.fetchErrChecks for the view to render as a status line, and polling
+// continues. Only the PR-checks error is touched here; the standalone-runs
+// error (m.fetchErrRuns) is managed by handleRepoRunsUpdate so a success
+// from one source cannot mask an ongoing error from the other.
 func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
-		m.fetchErr = msg.Err
-		m.fetchErrAt = time.Now()
+		m.fetchErrChecks = msg.Err
+		m.fetchErrChecksAt = time.Now()
 		debug.Log("repo checks fetch error", "err", msg.Err)
 		return m, nil
 	}
 
-	m.rateLimitRemaining = msg.RateLimitRemaining
+	// Take the minimum across sources, but accept the first observed value
+	// so the zero default doesn't pin rateLimitRemaining at 0 forever (which
+	// would trigger permanent rate-limit backoff and show "0 remaining").
+	// Mirrors handleRepoRunsUpdate so neither source can raise the value
+	// past what the other already observed.
+	if !m.fetchReceived || msg.RateLimitRemaining < m.rateLimitRemaining {
+		m.rateLimitRemaining = msg.RateLimitRemaining
+	}
 	m.lastUpdate = time.Now()
-	m.fetchErr = nil
-	m.fetchErrAt = time.Time{}
+	m.fetchErrChecks = nil
+	m.fetchErrChecksAt = time.Time{}
 	m.fetchReceived = true
 
 	now := time.Now()
@@ -151,11 +160,14 @@ func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, 
 // completed runs are kept if RunStartedAt is within the fade window.
 //
 // Transient fetch errors are non-fatal: the last good m.standaloneRuns is
-// preserved, the error is surfaced via m.fetchErr, and polling continues.
+// preserved, the error is surfaced via m.fetchErrRuns, and polling continues.
+// Only the standalone-runs error is touched here; the PR-checks error
+// (m.fetchErrChecks) is managed by handleRepoChecksUpdate so a success from
+// one source cannot mask an ongoing error from the other.
 func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
-		m.fetchErr = msg.Err
-		m.fetchErrAt = time.Now()
+		m.fetchErrRuns = msg.Err
+		m.fetchErrRunsAt = time.Now()
 		debug.Log("repo runs fetch error", "err", msg.Err)
 		return m, nil
 	}
@@ -167,8 +179,8 @@ func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.
 		m.rateLimitRemaining = msg.RateLimitRemaining
 	}
 	m.lastUpdate = time.Now()
-	m.fetchErr = nil
-	m.fetchErrAt = time.Time{}
+	m.fetchErrRuns = nil
+	m.fetchErrRunsAt = time.Time{}
 	m.fetchReceived = true
 
 	now := time.Now()

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -157,7 +157,10 @@ func (m *RepoModel) handleRepoRunsUpdate(msg RepoRunsUpdateMsg) (tea.Model, tea.
 		return m, nil
 	}
 
-	if msg.RateLimitRemaining < m.rateLimitRemaining {
+	// Take the minimum across sources, but accept the first observed value
+	// so the zero default doesn't pin rateLimitRemaining at 0 forever (which
+	// would trigger permanent rate-limit backoff and show "0 remaining").
+	if !m.fetchReceived || msg.RateLimitRemaining < m.rateLimitRemaining {
 		m.rateLimitRemaining = msg.RateLimitRemaining
 	}
 	m.lastUpdate = time.Now()

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -56,7 +56,10 @@ func (m RepoModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case RepoTickMsg:
 		// Rate-limit backoff: triple the interval when quota is critically low.
-		if m.rateLimitRemaining < rateBackoffThreshold {
+		// Gate on fetchReceived so the zero-value rateLimitRemaining (0) before
+		// the first successful response doesn't pin us in backoff forever and
+		// suppress the fetch commands that would clear that initial state.
+		if m.fetchReceived && m.rateLimitRemaining < rateBackoffThreshold {
 			debug.Log("rate limit backoff (repo)", "remaining", m.rateLimitRemaining, "threshold", rateBackoffThreshold)
 			return m, repoTick(m.refreshInterval * 3)
 		}

--- a/internal/tui/repoupdate_test.go
+++ b/internal/tui/repoupdate_test.go
@@ -1,10 +1,14 @@
 package tui
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	ghclient "github.com/fini-net/gh-observer/internal/github"
+	"github.com/mattn/go-runewidth"
 )
 
 func TestRepoChecksUpdateFadeOut(t *testing.T) {
@@ -355,5 +359,235 @@ func TestPluralS(t *testing.T) {
 		if got := pluralS(tt.n); got != tt.want {
 			t.Errorf("pluralS(%d) = %q, want %q", tt.n, got, tt.want)
 		}
+	}
+}
+
+func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
+	fadeSuccess := 15 * time.Minute
+	fadeFailure := 30 * time.Minute
+
+	// Seed the model with a known good PR so we can verify the error path
+	// preserves it rather than clearing it.
+	now := time.Now()
+	goodCompletedAt := now.Add(-1 * time.Minute)
+	seedPR := RepoModel{
+		prs: map[int]PRViewData{
+			42: {
+				Title: "Pre-existing PR",
+				CheckRuns: []ghclient.CheckRunInfo{
+					{Status: "in_progress", Name: "build"},
+					{Status: "completed", Conclusion: "success", Name: "lint", CompletedAt: &goodCompletedAt},
+				},
+				HeadCommitTime: now.Add(-2 * time.Minute),
+			},
+		},
+		fadeSuccess:    fadeSuccess,
+		fadeFailure:    fadeFailure,
+		fetchReceived:  true,
+		rateLimitRemaining: 4000,
+	}
+
+	t.Run("error preserves last good state and sets fetchErr", func(t *testing.T) {
+		m := seedPR
+		msg := RepoChecksUpdateMsg{
+			Err: fmt.Errorf("non-200 OK status code: 504 Gateway Timeout body: \"<!DOCTYPE html>..."),
+		}
+
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErr == nil {
+			t.Error("fetchErr should be set on error")
+		}
+		if rm.fetchErrAt.IsZero() {
+			t.Error("fetchErrAt should be set on error")
+		}
+		if rm.fetchReceived != true {
+			t.Error("fetchReceived should remain true after error (already received before)")
+		}
+		// Last good PRs preserved.
+		if len(rm.prs) != 1 {
+			t.Errorf("prs = %d, want 1 (last good state preserved)", len(rm.prs))
+		}
+		if _, ok := rm.prs[42]; !ok {
+			t.Error("PR #42 should still be present after error")
+		}
+		// Rate limit should be unchanged from before (not reset to 5000-default-on-error).
+		if rm.rateLimitRemaining != 4000 {
+			t.Errorf("rateLimitRemaining = %d, want 4000 (unchanged on error)", rm.rateLimitRemaining)
+		}
+	})
+
+	t.Run("success clears fetchErr and updates state", func(t *testing.T) {
+		// Start from an errored state.
+		m := seedPR
+		m.fetchErr = fmt.Errorf("previous 504")
+		m.fetchErrAt = time.Now().Add(-1 * time.Minute)
+
+		msg := RepoChecksUpdateMsg{
+			PRData: map[int]ghclient.PRCheckData{
+				7: {
+					Number: 7,
+					Title:  "New PR",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "in_progress", Name: "test"},
+					},
+				},
+			},
+			RateLimitRemaining: 4900,
+		}
+
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErr != nil {
+			t.Error("fetchErr should be cleared on success")
+		}
+		if !rm.fetchErrAt.IsZero() {
+			t.Error("fetchErrAt should be cleared on success")
+		}
+		if rm.fetchReceived != true {
+			t.Error("fetchReceived should remain true")
+		}
+		if rm.rateLimitRemaining != 4900 {
+			t.Errorf("rateLimitRemaining = %d, want 4900", rm.rateLimitRemaining)
+		}
+		// The PR map is replaced wholesale with the new message's PRs (fade-out
+		// only filters within the new message — it does not carry over PRs
+		// from the previous render). So only PR #7 should be present.
+		if len(rm.prs) != 1 {
+			t.Errorf("prs = %d, want 1 (new message replaces map)", len(rm.prs))
+		}
+		if _, ok := rm.prs[7]; !ok {
+			t.Error("PR #7 should be present after success")
+		}
+	})
+}
+
+func TestRepoRunsUpdateErrorNonFatal(t *testing.T) {
+	fadeSuccess := 15 * time.Minute
+	fadeFailure := 30 * time.Minute
+
+	seedRuns := []ghclient.BranchRunData{
+		{RunID: 1, Status: "in_progress", Event: "push", HeadBranch: "main"},
+	}
+	m := RepoModel{
+		standaloneRuns:    seedRuns,
+		fadeSuccess:       fadeSuccess,
+		fadeFailure:       fadeFailure,
+		fetchReceived:     true,
+		rateLimitRemaining: 4000,
+	}
+
+	t.Run("error preserves last good runs and sets fetchErr", func(t *testing.T) {
+		msg := RepoRunsUpdateMsg{
+			Err: fmt.Errorf("non-200 OK status code: 502 Bad Gateway"),
+		}
+
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErr == nil {
+			t.Error("fetchErr should be set on error")
+		}
+		if rm.fetchErrAt.IsZero() {
+			t.Error("fetchErrAt should be set on error")
+		}
+		if len(rm.standaloneRuns) != 1 {
+			t.Errorf("standaloneRuns = %d, want 1 (last good state preserved)", len(rm.standaloneRuns))
+		}
+	})
+
+	t.Run("success clears fetchErr", func(t *testing.T) {
+		m2 := m
+		m2.fetchErr = fmt.Errorf("previous 502")
+
+		msg := RepoRunsUpdateMsg{
+			Runs: []ghclient.BranchRunData{
+				{RunID: 2, Status: "in_progress", Event: "push", HeadBranch: "develop"},
+			},
+			RateLimitRemaining: 4900,
+		}
+
+		newModel, _ := m2.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErr != nil {
+			t.Error("fetchErr should be cleared on success")
+		}
+		if len(rm.standaloneRuns) != 1 {
+			t.Errorf("standaloneRuns = %d, want 1 (new active run)", len(rm.standaloneRuns))
+		}
+		if rm.standaloneRuns[0].RunID != 2 {
+			t.Errorf("standaloneRuns[0].RunID = %d, want 2", rm.standaloneRuns[0].RunID)
+		}
+	})
+}
+
+func TestRepoModelFetchReceivedGatesRateLimit(t *testing.T) {
+	// Verify the fetchReceived flag starts false on a fresh model.
+	m := NewRepoModel(
+		context.Background(), "tok", "o", "r",
+		30*time.Second, NewStyles(10, 9, 11, 8), true,
+		15*time.Minute, 30*time.Minute,
+	)
+	if m.fetchReceived {
+		t.Error("fetchReceived should be false on a fresh model")
+	}
+
+	// A successful RepoChecksUpdateMsg flips it true.
+	msg := RepoChecksUpdateMsg{
+		PRData:             map[int]ghclient.PRCheckData{},
+		RateLimitRemaining: 4500,
+	}
+	newModel, _ := m.Update(msg)
+	rm := newModel.(*RepoModel)
+	if !rm.fetchReceived {
+		t.Error("fetchReceived should be true after a successful checks update")
+	}
+}
+
+func TestTruncateFetchError(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		max    int
+		want   string
+	}{
+		{
+			name:  "short passthrough",
+			input: "connection refused",
+			max:   80,
+			want:  "connection refused",
+		},
+		{
+			name:  "under-max passthrough",
+			input: "0123456789012345678901234567890123456789012345678901234567890123", // 64 chars
+			max:   80,
+			want:  "0123456789012345678901234567890123456789012345678901234567890123",
+		},
+		{
+			name:  "truncates long 504 body",
+			input: `non-200 OK status code: 504 Gateway Timeout body: "<!DOCTYPE html><html><head><title>Server Error</title></head><body><h1>Server Error</h1><p>Sorry about that.</p></body></html>`,
+			max:   80,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateFetchError(tt.input, tt.max)
+			if tt.want != "" {
+				if got != tt.want {
+					t.Errorf("truncateFetchError() = %q, want %q", got, tt.want)
+				}
+				return
+			}
+			// For truncation cases, just verify it fits and ends with ellipsis.
+			if runewidth.StringWidth(got) > tt.max {
+				t.Errorf("truncateFetchError() width = %d, want <= %d", runewidth.StringWidth(got), tt.max)
+			}
+			if !strings.HasSuffix(got, "…") {
+				t.Errorf("truncateFetchError() = %q, want suffix …", got)
+			}
+		})
 	}
 }

--- a/internal/tui/repoupdate_test.go
+++ b/internal/tui/repoupdate_test.go
@@ -253,7 +253,7 @@ func TestRepoRunsUpdateFadeOut(t *testing.T) {
 		},
 		{
 			name:        "empty list",
-			runs:         []ghclient.BranchRunData{},
+			runs:        []ghclient.BranchRunData{},
 			wantVisible: 0,
 		},
 	}
@@ -329,7 +329,7 @@ func TestRepoModelFadeWindow(t *testing.T) {
 		name        string
 		fadeSuccess time.Duration
 		fadeFailure time.Duration
-		want         time.Duration
+		want        time.Duration
 	}{
 		{"failure larger", 15 * time.Minute, 30 * time.Minute, 30 * time.Minute},
 		{"success larger", 30 * time.Minute, 15 * time.Minute, 30 * time.Minute},
@@ -381,13 +381,13 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 				HeadCommitTime: now.Add(-2 * time.Minute),
 			},
 		},
-		fadeSuccess:    fadeSuccess,
-		fadeFailure:    fadeFailure,
-		fetchReceived:  true,
+		fadeSuccess:        fadeSuccess,
+		fadeFailure:        fadeFailure,
+		fetchReceived:      true,
 		rateLimitRemaining: 4000,
 	}
 
-	t.Run("error preserves last good state and sets fetchErr", func(t *testing.T) {
+	t.Run("error preserves last good state and sets fetchErrChecks", func(t *testing.T) {
 		m := seedPR
 		msg := RepoChecksUpdateMsg{
 			Err: fmt.Errorf("non-200 OK status code: 504 Gateway Timeout body: \"<!DOCTYPE html>..."),
@@ -396,11 +396,15 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 		newModel, _ := m.Update(msg)
 		rm := newModel.(*RepoModel)
 
-		if rm.fetchErr == nil {
-			t.Error("fetchErr should be set on error")
+		if rm.fetchErrChecks == nil {
+			t.Error("fetchErrChecks should be set on error")
 		}
-		if rm.fetchErrAt.IsZero() {
-			t.Error("fetchErrAt should be set on error")
+		if rm.fetchErrChecksAt.IsZero() {
+			t.Error("fetchErrChecksAt should be set on error")
+		}
+		// The runs-source error should be untouched.
+		if rm.fetchErrRuns != nil {
+			t.Error("fetchErrRuns should not be touched by a checks-source error")
 		}
 		if rm.fetchReceived != true {
 			t.Error("fetchReceived should remain true after error (already received before)")
@@ -418,11 +422,14 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 		}
 	})
 
-	t.Run("success clears fetchErr and updates state", func(t *testing.T) {
-		// Start from an errored state.
+	t.Run("success clears fetchErrChecks only and updates state", func(t *testing.T) {
+		// Start from an errored state on BOTH sources. The checks success
+		// must clear only fetchErrChecks, leaving fetchErrRuns intact.
 		m := seedPR
-		m.fetchErr = fmt.Errorf("previous 504")
-		m.fetchErrAt = time.Now().Add(-1 * time.Minute)
+		m.fetchErrChecks = fmt.Errorf("previous 504")
+		m.fetchErrChecksAt = time.Now().Add(-1 * time.Minute)
+		m.fetchErrRuns = fmt.Errorf("ongoing 502 from runs source")
+		m.fetchErrRunsAt = time.Now().Add(-30 * time.Second)
 
 		msg := RepoChecksUpdateMsg{
 			PRData: map[int]ghclient.PRCheckData{
@@ -440,17 +447,28 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 		newModel, _ := m.Update(msg)
 		rm := newModel.(*RepoModel)
 
-		if rm.fetchErr != nil {
-			t.Error("fetchErr should be cleared on success")
+		if rm.fetchErrChecks != nil {
+			t.Error("fetchErrChecks should be cleared on checks success")
 		}
-		if !rm.fetchErrAt.IsZero() {
-			t.Error("fetchErrAt should be cleared on success")
+		if !rm.fetchErrChecksAt.IsZero() {
+			t.Error("fetchErrChecksAt should be cleared on checks success")
+		}
+		// The runs-side error must survive the checks success — this is
+		// the core isolation property fix #2 adds.
+		if rm.fetchErrRuns == nil {
+			t.Error("fetchErrRuns should survive a checks-source success")
+		}
+		if rm.fetchErrRunsAt.IsZero() {
+			t.Error("fetchErrRunsAt should survive a checks-source success")
 		}
 		if rm.fetchReceived != true {
 			t.Error("fetchReceived should remain true")
 		}
-		if rm.rateLimitRemaining != 4900 {
-			t.Errorf("rateLimitRemaining = %d, want 4900", rm.rateLimitRemaining)
+		// Fix #4: handleRepoChecksUpdate now applies the min-across-sources
+		// guard, so a 4900 message against a seeded 4000 leaves 4000 in
+		// place rather than overwriting with 4900.
+		if rm.rateLimitRemaining != 4000 {
+			t.Errorf("rateLimitRemaining = %d, want 4000 (min across sources)", rm.rateLimitRemaining)
 		}
 		// The PR map is replaced wholesale with the new message's PRs (fade-out
 		// only filters within the new message — it does not carry over PRs
@@ -460,6 +478,29 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 		}
 		if _, ok := rm.prs[7]; !ok {
 			t.Error("PR #7 should be present after success")
+		}
+	})
+
+	t.Run("checks success does not clear runs error", func(t *testing.T) {
+		// Minimal isolation check: seed only fetchErrRuns, send a successful
+		// RepoChecksUpdateMsg, and assert fetchErrRuns is still set.
+		m := seedPR
+		m.fetchErrRuns = fmt.Errorf("ongoing 502")
+		m.fetchErrRunsAt = time.Now().Add(-30 * time.Second)
+
+		msg := RepoChecksUpdateMsg{
+			PRData:             map[int]ghclient.PRCheckData{},
+			RateLimitRemaining: 4900,
+		}
+
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErrRuns == nil {
+			t.Error("fetchErrRuns should survive a checks-source success")
+		}
+		if rm.fetchErrChecks != nil {
+			t.Error("fetchErrChecks should be nil on a checks success")
 		}
 	})
 }
@@ -472,14 +513,14 @@ func TestRepoRunsUpdateErrorNonFatal(t *testing.T) {
 		{RunID: 1, Status: "in_progress", Event: "push", HeadBranch: "main"},
 	}
 	m := RepoModel{
-		standaloneRuns:    seedRuns,
-		fadeSuccess:       fadeSuccess,
-		fadeFailure:       fadeFailure,
-		fetchReceived:     true,
+		standaloneRuns:     seedRuns,
+		fadeSuccess:        fadeSuccess,
+		fadeFailure:        fadeFailure,
+		fetchReceived:      true,
 		rateLimitRemaining: 4000,
 	}
 
-	t.Run("error preserves last good runs and sets fetchErr", func(t *testing.T) {
+	t.Run("error preserves last good runs and sets fetchErrRuns", func(t *testing.T) {
 		msg := RepoRunsUpdateMsg{
 			Err: fmt.Errorf("non-200 OK status code: 502 Bad Gateway"),
 		}
@@ -487,20 +528,29 @@ func TestRepoRunsUpdateErrorNonFatal(t *testing.T) {
 		newModel, _ := m.Update(msg)
 		rm := newModel.(*RepoModel)
 
-		if rm.fetchErr == nil {
-			t.Error("fetchErr should be set on error")
+		if rm.fetchErrRuns == nil {
+			t.Error("fetchErrRuns should be set on error")
 		}
-		if rm.fetchErrAt.IsZero() {
-			t.Error("fetchErrAt should be set on error")
+		if rm.fetchErrRunsAt.IsZero() {
+			t.Error("fetchErrRunsAt should be set on error")
+		}
+		// The checks-source error should be untouched.
+		if rm.fetchErrChecks != nil {
+			t.Error("fetchErrChecks should not be touched by a runs-source error")
 		}
 		if len(rm.standaloneRuns) != 1 {
 			t.Errorf("standaloneRuns = %d, want 1 (last good state preserved)", len(rm.standaloneRuns))
 		}
 	})
 
-	t.Run("success clears fetchErr", func(t *testing.T) {
+	t.Run("success clears fetchErrRuns only", func(t *testing.T) {
+		// Seed both source errors; the runs success must clear only
+		// fetchErrRuns, leaving fetchErrChecks intact.
 		m2 := m
-		m2.fetchErr = fmt.Errorf("previous 502")
+		m2.fetchErrRuns = fmt.Errorf("previous 502")
+		m2.fetchErrRunsAt = time.Now().Add(-1 * time.Minute)
+		m2.fetchErrChecks = fmt.Errorf("ongoing 504 from checks source")
+		m2.fetchErrChecksAt = time.Now().Add(-30 * time.Second)
 
 		msg := RepoRunsUpdateMsg{
 			Runs: []ghclient.BranchRunData{
@@ -512,14 +562,137 @@ func TestRepoRunsUpdateErrorNonFatal(t *testing.T) {
 		newModel, _ := m2.Update(msg)
 		rm := newModel.(*RepoModel)
 
-		if rm.fetchErr != nil {
-			t.Error("fetchErr should be cleared on success")
+		if rm.fetchErrRuns != nil {
+			t.Error("fetchErrRuns should be cleared on runs success")
+		}
+		// The checks-side error must survive the runs success.
+		if rm.fetchErrChecks == nil {
+			t.Error("fetchErrChecks should survive a runs-source success")
+		}
+		if rm.fetchErrChecksAt.IsZero() {
+			t.Error("fetchErrChecksAt should survive a runs-source success")
 		}
 		if len(rm.standaloneRuns) != 1 {
 			t.Errorf("standaloneRuns = %d, want 1 (new active run)", len(rm.standaloneRuns))
 		}
 		if rm.standaloneRuns[0].RunID != 2 {
 			t.Errorf("standaloneRuns[0].RunID = %d, want 2", rm.standaloneRuns[0].RunID)
+		}
+	})
+
+	t.Run("runs success does not clear checks error", func(t *testing.T) {
+		// Minimal isolation check: seed only fetchErrChecks, send a
+		// successful RepoRunsUpdateMsg, and assert fetchErrChecks is still set.
+		m3 := m
+		m3.fetchErrChecks = fmt.Errorf("ongoing 504")
+		m3.fetchErrChecksAt = time.Now().Add(-30 * time.Second)
+
+		msg := RepoRunsUpdateMsg{
+			Runs: []ghclient.BranchRunData{
+				{RunID: 3, Status: "in_progress", Event: "push", HeadBranch: "main"},
+			},
+			RateLimitRemaining: 4900,
+		}
+
+		newModel, _ := m3.Update(msg)
+		rm := newModel.(*RepoModel)
+
+		if rm.fetchErrChecks == nil {
+			t.Error("fetchErrChecks should survive a runs-source success")
+		}
+		if rm.fetchErrRuns != nil {
+			t.Error("fetchErrRuns should be nil on a runs success")
+		}
+	})
+}
+
+// TestRepoChecksUpdateRateLimitMinAcrossSources verifies fix #4: the checks
+// source applies a min-across-sources guard (mirroring handleRepoRunsUpdate)
+// so a GraphQL response with a higher remaining quota cannot raise the model
+// value past what the REST runs source already observed.
+func TestRepoChecksUpdateRateLimitMinAcrossSources(t *testing.T) {
+	t.Run("min wins when checks quota is higher", func(t *testing.T) {
+		m := RepoModel{
+			prs:                make(map[int]PRViewData),
+			fadeSuccess:        15 * time.Minute,
+			fadeFailure:        30 * time.Minute,
+			fetchReceived:      true,
+			rateLimitRemaining: 4000,
+		}
+		msg := RepoChecksUpdateMsg{
+			PRData:             map[int]ghclient.PRCheckData{},
+			RateLimitRemaining: 4900,
+		}
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+		if rm.rateLimitRemaining != 4000 {
+			t.Errorf("rateLimitRemaining = %d, want 4000 (min across sources)", rm.rateLimitRemaining)
+		}
+	})
+
+	t.Run("first observed wins on a fresh model", func(t *testing.T) {
+		m := RepoModel{
+			prs:           make(map[int]PRViewData),
+			fadeSuccess:   15 * time.Minute,
+			fadeFailure:   30 * time.Minute,
+			fetchReceived: false,
+		}
+		msg := RepoChecksUpdateMsg{
+			PRData:             map[int]ghclient.PRCheckData{},
+			RateLimitRemaining: 4500,
+		}
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+		if rm.rateLimitRemaining != 4500 {
+			t.Errorf("rateLimitRemaining = %d, want 4500 (first observed)", rm.rateLimitRemaining)
+		}
+		if !rm.fetchReceived {
+			t.Error("fetchReceived should be true after first successful checks update")
+		}
+	})
+}
+
+// TestRepoRunsUpdateRateLimitMinAcrossSources hardens the existing behavior
+// on the runs side (the min-across-sources guard in handleRepoRunsUpdate) so
+// it stays tested alongside the new checks-side equivalent above.
+func TestRepoRunsUpdateRateLimitMinAcrossSources(t *testing.T) {
+	t.Run("min wins when runs quota is higher", func(t *testing.T) {
+		m := RepoModel{
+			standaloneRuns:     []ghclient.BranchRunData{},
+			fadeSuccess:        15 * time.Minute,
+			fadeFailure:        30 * time.Minute,
+			fetchReceived:      true,
+			rateLimitRemaining: 4000,
+		}
+		msg := RepoRunsUpdateMsg{
+			Runs:               []ghclient.BranchRunData{},
+			RateLimitRemaining: 4900,
+		}
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+		if rm.rateLimitRemaining != 4000 {
+			t.Errorf("rateLimitRemaining = %d, want 4000 (min across sources)", rm.rateLimitRemaining)
+		}
+	})
+
+	t.Run("first observed wins on a fresh model", func(t *testing.T) {
+		m := RepoModel{
+			standaloneRuns: []ghclient.BranchRunData{},
+			fadeSuccess:    15 * time.Minute,
+			fadeFailure:    30 * time.Minute,
+			fetchReceived:  false,
+		}
+		msg := RepoRunsUpdateMsg{
+			Runs:               []ghclient.BranchRunData{},
+			RateLimitRemaining: 4500,
+		}
+		newModel, _ := m.Update(msg)
+		rm := newModel.(*RepoModel)
+		if rm.rateLimitRemaining != 4500 {
+			t.Errorf("rateLimitRemaining = %d, want 4500 (first observed)", rm.rateLimitRemaining)
+		}
+		if !rm.fetchReceived {
+			t.Error("fetchReceived should be true after first successful runs update")
 		}
 	})
 }
@@ -549,10 +722,10 @@ func TestRepoModelFetchReceivedGatesRateLimit(t *testing.T) {
 
 func TestTruncateFetchError(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		max    int
-		want   string
+		name  string
+		input string
+		max   int
+		want  string
 	}{
 		{
 			name:  "short passthrough",

--- a/internal/tui/repoupdate_test.go
+++ b/internal/tui/repoupdate_test.go
@@ -1,0 +1,359 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	ghclient "github.com/fini-net/gh-observer/internal/github"
+)
+
+func TestRepoChecksUpdateFadeOut(t *testing.T) {
+	now := time.Now()
+	fadeSuccess := 15 * time.Minute
+	fadeFailure := 30 * time.Minute
+
+	successCompletedAt := now.Add(-10 * time.Minute)
+	failureCompletedAt := now.Add(-20 * time.Minute)
+	fadedSuccessCompletedAt := now.Add(-20 * time.Minute)
+	fadedFailureCompletedAt := now.Add(-45 * time.Minute)
+
+	tests := []struct {
+		name              string
+		prData            map[int]ghclient.PRCheckData
+		wantPRCount       int
+		wantVisibleChecks int
+	}{
+		{
+			name: "active check keeps PR visible",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Active PR",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "in_progress", Name: "build"},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+		{
+			name: "queued check keeps PR visible",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Queued PR",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "queued", Name: "deploy"},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+		{
+			name: "recent success stays visible",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Recent success",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "success", Name: "build", CompletedAt: &successCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+		{
+			name: "faded success removed",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Old success",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "success", Name: "build", CompletedAt: &fadedSuccessCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       0,
+			wantVisibleChecks: 0,
+		},
+		{
+			name: "recent failure stays visible",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Recent failure",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "failure", Name: "build", CompletedAt: &failureCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+		{
+			name: "faded failure removed",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Old failure",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "failure", Name: "build", CompletedAt: &fadedFailureCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       0,
+			wantVisibleChecks: 0,
+		},
+		{
+			name: "mixed checks - active keeps PR visible, faded dropped",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Mixed PR",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "success", Name: "old-build", CompletedAt: &fadedSuccessCompletedAt},
+						{Status: "in_progress", Name: "test"},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+		{
+			name: "all faded - PR dropped entirely",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "All faded",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "success", Name: "a", CompletedAt: &fadedSuccessCompletedAt},
+						{Status: "completed", Conclusion: "failure", Name: "b", CompletedAt: &fadedFailureCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       0,
+			wantVisibleChecks: 0,
+		},
+		{
+			name: "multiple PRs - only active ones kept",
+			prData: map[int]ghclient.PRCheckData{
+				1: {
+					Number: 1,
+					Title:  "Active",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "in_progress", Name: "build"},
+					},
+				},
+				2: {
+					Number: 2,
+					Title:  "Faded",
+					CheckRuns: []ghclient.CheckRunInfo{
+						{Status: "completed", Conclusion: "success", Name: "build", CompletedAt: &fadedSuccessCompletedAt},
+					},
+				},
+			},
+			wantPRCount:       1,
+			wantVisibleChecks: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := RepoModel{
+				prs:         make(map[int]PRViewData),
+				fadeSuccess: fadeSuccess,
+				fadeFailure: fadeFailure,
+			}
+
+			msg := RepoChecksUpdateMsg{
+				PRData:             tt.prData,
+				RateLimitRemaining: 5000,
+			}
+
+			newModel, _ := m.Update(msg)
+			rm := newModel.(*RepoModel)
+
+			if len(rm.prs) != tt.wantPRCount {
+				t.Errorf("visible PRs = %d, want %d", len(rm.prs), tt.wantPRCount)
+			}
+
+			visibleChecks := 0
+			for _, pr := range rm.prs {
+				visibleChecks += len(pr.CheckRuns)
+			}
+			if visibleChecks != tt.wantVisibleChecks {
+				t.Errorf("visible checks = %d, want %d", visibleChecks, tt.wantVisibleChecks)
+			}
+		})
+	}
+}
+
+func TestRepoRunsUpdateFadeOut(t *testing.T) {
+	now := time.Now()
+	fadeSuccess := 15 * time.Minute
+	fadeFailure := 30 * time.Minute
+
+	recentStart := now.Add(-5 * time.Minute)
+	fadedStart := now.Add(-45 * time.Minute)
+
+	tests := []struct {
+		name        string
+		runs        []ghclient.BranchRunData
+		wantVisible int
+	}{
+		{
+			name: "in_progress run stays visible",
+			runs: []ghclient.BranchRunData{
+				{RunID: 1, Status: "in_progress", Event: "push", HeadBranch: "main"},
+			},
+			wantVisible: 1,
+		},
+		{
+			name: "queued run stays visible",
+			runs: []ghclient.BranchRunData{
+				{RunID: 2, Status: "queued", Event: "push", HeadBranch: "main"},
+			},
+			wantVisible: 1,
+		},
+		{
+			name: "recently completed success stays visible",
+			runs: []ghclient.BranchRunData{
+				{RunID: 3, Status: "completed", Conclusion: "success", Event: "push", HeadBranch: "main", RunStartedAt: recentStart},
+			},
+			wantVisible: 1,
+		},
+		{
+			name: "recently completed failure stays visible",
+			runs: []ghclient.BranchRunData{
+				{RunID: 4, Status: "completed", Conclusion: "failure", Event: "push", HeadBranch: "main", RunStartedAt: recentStart},
+			},
+			wantVisible: 1,
+		},
+		{
+			name: "faded completed run removed",
+			runs: []ghclient.BranchRunData{
+				{RunID: 5, Status: "completed", Conclusion: "success", Event: "push", HeadBranch: "main", RunStartedAt: fadedStart},
+			},
+			wantVisible: 0,
+		},
+		{
+			name: "mixed - active and faded",
+			runs: []ghclient.BranchRunData{
+				{RunID: 6, Status: "in_progress", Event: "push", HeadBranch: "main"},
+				{RunID: 7, Status: "completed", Conclusion: "success", Event: "schedule", HeadBranch: "main", RunStartedAt: fadedStart},
+			},
+			wantVisible: 1,
+		},
+		{
+			name:        "empty list",
+			runs:         []ghclient.BranchRunData{},
+			wantVisible: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := RepoModel{
+				prs:         make(map[int]PRViewData),
+				fadeSuccess: fadeSuccess,
+				fadeFailure: fadeFailure,
+			}
+
+			msg := RepoRunsUpdateMsg{
+				Runs:               tt.runs,
+				RateLimitRemaining: 5000,
+			}
+
+			newModel, _ := m.Update(msg)
+			rm := newModel.(*RepoModel)
+
+			if len(rm.standaloneRuns) != tt.wantVisible {
+				t.Errorf("visible branch runs = %d, want %d", len(rm.standaloneRuns), tt.wantVisible)
+			}
+		})
+	}
+}
+
+func TestIsActiveBranchRun(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"in_progress", true},
+		{"queued", true},
+		{"waiting", true},
+		{"pending", true},
+		{"completed", false},
+		{"", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := isActiveBranchRun(tt.status); got != tt.want {
+				t.Errorf("isActiveBranchRun(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoModelSortedPRNumbers(t *testing.T) {
+	m := RepoModel{
+		prs: map[int]PRViewData{
+			3: {Title: "c"},
+			1: {Title: "a"},
+			2: {Title: "b"},
+		},
+	}
+	got := m.sortedPRNumbers()
+	want := []int{1, 2, 3}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sortedPRNumbers[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRepoModelFadeWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		fadeSuccess time.Duration
+		fadeFailure time.Duration
+		want         time.Duration
+	}{
+		{"failure larger", 15 * time.Minute, 30 * time.Minute, 30 * time.Minute},
+		{"success larger", 30 * time.Minute, 15 * time.Minute, 30 * time.Minute},
+		{"equal", 15 * time.Minute, 15 * time.Minute, 15 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := RepoModel{fadeSuccess: tt.fadeSuccess, fadeFailure: tt.fadeFailure}
+			if got := m.fadeWindow(); got != tt.want {
+				t.Errorf("fadeWindow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPluralS(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "s"},
+		{1, ""},
+		{2, "s"},
+		{10, "s"},
+	}
+	for _, tt := range tests {
+		if got := pluralS(tt.n); got != tt.want {
+			t.Errorf("pluralS(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/repoview.go
+++ b/internal/tui/repoview.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"charm.land/lipgloss/v2"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 	"github.com/fini-net/gh-observer/internal/timing"
 	"github.com/mattn/go-runewidth"
@@ -71,12 +71,24 @@ func (m RepoModel) View() tea.View {
 		}
 	}
 
-	// Non-fatal fetch error status line. The last good state remains on screen
-	// above this line; polling continues and the line clears on next success.
-	if m.fetchErr != nil {
-		errText := truncateFetchError(m.fetchErr.Error(), 80)
-		age := timing.FormatDuration(time.Since(m.fetchErrAt))
-		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Fetch error: %s — %s ago]", errText, age)))
+	// Non-fatal fetch error status line. The last good state remains on
+	// screen above this line; polling continues and the relevant source's
+	// line clears on its next success. The two fetch sources (GraphQL PR
+	// checks and REST standalone runs) track errors independently so a
+	// success from one cannot mask an ongoing error from the other. Render
+	// whichever source's error is most recent, prefixed by the source.
+	var err error
+	var errAt time.Time
+	var source string
+	if !m.fetchErrChecksAt.IsZero() && (m.fetchErrRunsAt.IsZero() || m.fetchErrChecksAt.After(m.fetchErrRunsAt)) {
+		err, errAt, source = m.fetchErrChecks, m.fetchErrChecksAt, "PR checks"
+	} else if m.fetchErrRuns != nil {
+		err, errAt, source = m.fetchErrRuns, m.fetchErrRunsAt, "Repo runs"
+	}
+	if err != nil {
+		errText := truncateFetchError(err.Error(), 70)
+		age := timing.FormatDuration(time.Since(errAt))
+		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [%s fetch error: %s — %s ago]", source, errText, age)))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/repoview.go
+++ b/internal/tui/repoview.go
@@ -14,13 +14,14 @@ import (
 )
 
 // View renders the repo-watch state: a repo header, a summary line, PR groups
-// (each with its checks), standalone branch-run groups, the rate-limit indicator,
-// and the quit hint.
+// (each with its checks), standalone branch-run groups, the rate-limit
+// indicator, an optional non-fatal fetch-error status line, and the quit hint.
+//
+// Repo mode is persistent: transient fetch errors (e.g. 504 Gateway Timeout)
+// do NOT replace the screen. The last good state stays on screen and the
+// error is surfaced as a red status line so the user knows something is wrong
+// while polling continues and self-heals when the API returns.
 func (m RepoModel) View() tea.View {
-	if m.err != nil {
-		return tea.NewView(m.styles.Error.Render(fmt.Sprintf("Error: %v\n", m.err)))
-	}
-
 	var b strings.Builder
 
 	utcTime := time.Now().UTC().Format("15:04:05 UTC")
@@ -56,12 +57,26 @@ func (m RepoModel) View() tea.View {
 		}
 	}
 
-	// Two-tier rate-limit indicator: red under minRateLimitForFetch, yellow under rateWarningThreshold.
-	if m.rateLimitRemaining < minRateLimitForFetch {
-		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
-		b.WriteString("\n")
-	} else if m.rateLimitRemaining < rateWarningThreshold {
-		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+	// Two-tier rate-limit indicator: red under minRateLimitForFetch, yellow
+	// under rateWarningThreshold. Only render once we've actually received a
+	// response — before that, rateLimitRemaining is the Go zero value (0) and
+	// showing "[Rate limit: 0 remaining]" in red would be misleading.
+	if m.fetchReceived {
+		if m.rateLimitRemaining < minRateLimitForFetch {
+			b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+			b.WriteString("\n")
+		} else if m.rateLimitRemaining < rateWarningThreshold {
+			b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+			b.WriteString("\n")
+		}
+	}
+
+	// Non-fatal fetch error status line. The last good state remains on screen
+	// above this line; polling continues and the line clears on next success.
+	if m.fetchErr != nil {
+		errText := truncateFetchError(m.fetchErr.Error(), 80)
+		age := timing.FormatDuration(time.Since(m.fetchErrAt))
+		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Fetch error: %s — %s ago]", errText, age)))
 		b.WriteString("\n")
 	}
 
@@ -72,6 +87,16 @@ func (m RepoModel) View() tea.View {
 	}
 
 	return tea.NewView(b.String())
+}
+
+// truncateFetchError shortens an error message to fit within maxWidth terminal
+// display cells, appending an ellipsis if truncation occurs. GitHub 504 errors
+// embed a large HTML body that would otherwise span many terminal lines.
+func truncateFetchError(s string, maxWidth int) string {
+	if runewidth.StringWidth(s) <= maxWidth {
+		return s
+	}
+	return runewidth.Truncate(s, maxWidth, "…")
 }
 
 // renderPRGroup renders a single PR's header and its (already fade-filtered) checks.

--- a/internal/tui/repoview.go
+++ b/internal/tui/repoview.go
@@ -1,0 +1,345 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	tea "charm.land/bubbletea/v2"
+	ghclient "github.com/fini-net/gh-observer/internal/github"
+	"github.com/fini-net/gh-observer/internal/timing"
+	"github.com/mattn/go-runewidth"
+)
+
+// View renders the repo-watch state: a repo header, a summary line, PR groups
+// (each with its checks), standalone branch-run groups, the rate-limit indicator,
+// and the quit hint.
+func (m RepoModel) View() tea.View {
+	if m.err != nil {
+		return tea.NewView(m.styles.Error.Render(fmt.Sprintf("Error: %v\n", m.err)))
+	}
+
+	var b strings.Builder
+
+	utcTime := time.Now().UTC().Format("15:04:05 UTC")
+	timeSinceUpdate := time.Since(m.lastUpdate)
+
+	repoHeader := m.styles.Header.Render(fmt.Sprintf("%s/%s", m.owner, m.repo))
+	prCount := len(m.prs)
+	branchRunCount := len(m.standaloneRuns)
+
+	summaryParts := []string{
+		fmt.Sprintf("%d active PR%s", prCount, pluralS(prCount)),
+	}
+	if branchRunCount > 0 {
+		summaryParts = append(summaryParts, fmt.Sprintf("%d branch run%s", branchRunCount, pluralS(branchRunCount)))
+	}
+	summaryParts = append(summaryParts, fmt.Sprintf("Updated %s ago", timing.FormatDuration(timeSinceUpdate)))
+	summaryLine := strings.Join(summaryParts, "  •  ")
+
+	fmt.Fprintf(&b, "%s %s\n", repoHeader, utcTime)
+	fmt.Fprintf(&b, "%s\n", summaryLine)
+	b.WriteString("\n")
+
+	if prCount == 0 && branchRunCount == 0 {
+		fmt.Fprintf(&b, "%s ", m.spinner.View())
+		b.WriteString(m.styles.Running.Render("No active PRs or branch runs..."))
+		b.WriteString("\n\n")
+	} else {
+		for _, prNum := range m.sortedPRNumbers() {
+			m.renderPRGroup(&b, prNum, m.prs[prNum])
+		}
+		if branchRunCount > 0 {
+			m.renderStandaloneRunsSection(&b)
+		}
+	}
+
+	// Two-tier rate-limit indicator: red under minRateLimitForFetch, yellow under rateWarningThreshold.
+	if m.rateLimitRemaining < minRateLimitForFetch {
+		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		b.WriteString("\n")
+	} else if m.rateLimitRemaining < rateWarningThreshold {
+		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+
+	if !m.quitting {
+		b.WriteString("Press q to quit\n")
+	}
+
+	return tea.NewView(b.String())
+}
+
+// renderPRGroup renders a single PR's header and its (already fade-filtered) checks.
+func (m RepoModel) renderPRGroup(b *strings.Builder, prNum int, prData PRViewData) {
+	prHeader := m.styles.Header.Render(fmt.Sprintf("PR #%d: %s", prNum, prData.Title))
+	b.WriteString(prHeader)
+	b.WriteString("\n")
+
+	if len(prData.CheckRuns) == 0 {
+		b.WriteString("  No checks\n\n")
+		return
+	}
+
+	widths := CalculateColumnWidths(prData.CheckRuns, prData.HeadCommitTime, nil)
+
+	for _, check := range prData.CheckRuns {
+		line := m.renderRepoCheckRun(check, prData.HeadCommitTime, widths)
+		b.WriteString(line)
+	}
+
+	b.WriteString("\n")
+}
+
+// renderRepoCheckRun renders one PR check row, indented two spaces under the PR header.
+// Reuses display.go helpers (no HistAvg column — jobAverages is nil in repo mode).
+func (m RepoModel) renderRepoCheckRun(check ghclient.CheckRunInfo, headCommitTime time.Time, widths ColumnWidths) string {
+	nameCol := BuildNameColumn(check, widths, m.enableLinks)
+	queueText := FormatQueueLatency(check, headCommitTime)
+	durationText := FormatDuration(check)
+	avgText := FormatAvg(check, nil)
+
+	icon := GetCheckIcon(check.Status, check.Conclusion)
+	style := styleForCheck(check.Status, check.Conclusion, m.styles)
+
+	queueCol, _, durationCol, avgCol := FormatAlignedColumns(queueText, FormatCheckNameWithTruncate(check, widths.NameWidth), durationText, avgText, widths)
+
+	styledIcon := style.Render(icon)
+	styledDuration := style.Render(durationCol)
+	styledAvg := style.Render(avgCol)
+
+	styledName := nameCol
+	if check.Conclusion == "failure" || check.Conclusion == "timed_out" {
+		styledName = style.Render(nameCol)
+	}
+
+	return "  " + queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + styledAvg + "\n"
+}
+
+// renderStandaloneRunsSection renders standalone (non-PR) workflow runs grouped by branch.
+func (m RepoModel) renderStandaloneRunsSection(b *strings.Builder) {
+	branchGroups := m.groupBranchRunsByBranch()
+	for _, branch := range sortedBranchNames(branchGroups) {
+		m.renderBranchGroup(b, branch, branchGroups[branch])
+	}
+}
+
+// renderBranchGroup renders a "Branch: name" header followed by its runs and their jobs.
+func (m RepoModel) renderBranchGroup(b *strings.Builder, branch string, runs []ghclient.BranchRunData) {
+	b.WriteString(m.styles.Header.Render(fmt.Sprintf("Branch: %s", branch)))
+	b.WriteString("\n")
+
+	for _, run := range runs {
+		m.renderBranchRunHeader(b, run)
+
+		if len(run.Jobs) > 0 {
+			widths := calculateBranchRunColumnWidths(run.Jobs)
+			for _, job := range run.Jobs {
+				line := m.renderBranchRunJob(job, widths)
+				b.WriteString(line)
+			}
+		} else if run.Status != "completed" {
+			b.WriteString("    ")
+			b.WriteString(m.styles.Queued.Render("Waiting for jobs...\n"))
+		}
+	}
+
+	b.WriteString("\n")
+}
+
+// renderBranchRunHeader renders the run-level row (icon + title + event + duration).
+func (m RepoModel) renderBranchRunHeader(b *strings.Builder, run ghclient.BranchRunData) {
+	icon := GetCheckIcon(run.Status, run.Conclusion)
+	style := styleForCheck(run.Status, run.Conclusion, m.styles)
+
+	eventAnnotation := ""
+	if run.Event != "" && run.Event != "push" {
+		eventAnnotation = fmt.Sprintf(" (%s)", run.Event)
+	}
+
+	durationText := formatBranchRunDuration(run)
+	title := run.DisplayTitle
+	if run.WorkflowName != "" && title == "" {
+		title = run.WorkflowName
+	}
+
+	styledIcon := style.Render(icon)
+	styledTitle := style.Render(fmt.Sprintf("%s%s", title, eventAnnotation))
+	styledDuration := style.Render(durationText)
+
+	fmt.Fprintf(b, "  %s %s  %s\n", styledIcon, styledTitle, styledDuration)
+}
+
+// renderBranchRunJob renders a single job row under a branch run header.
+func (m RepoModel) renderBranchRunJob(job ghclient.CheckRunInfo, widths branchRunColumnWidths) string {
+	icon := GetCheckIcon(job.Status, job.Conclusion)
+	style := styleForCheck(job.Status, job.Conclusion, m.styles)
+
+	nameText := formatBranchJobNameTruncate(job, widths.nameWidth)
+	namePad := max(widths.nameWidth-runewidth.StringWidth(nameText), 0)
+	nameCol := nameText + strings.Repeat(" ", namePad)
+
+	durationText := formatBranchJobDuration(job)
+	durationPad := max(widths.durationWidth-runewidth.StringWidth(durationText), 0)
+	durationCol := strings.Repeat(" ", durationPad) + durationText
+
+	styledIcon := style.Render(icon)
+	styledDuration := style.Render(durationCol)
+
+	styledName := nameCol
+	if job.Conclusion == "failure" || job.Conclusion == "timed_out" {
+		styledName = style.Render(nameCol)
+	}
+
+	return "    " + styledIcon + " " + styledName + "  " + styledDuration + "\n"
+}
+
+// styleForCheck returns the lipgloss style for a status/conclusion pair.
+func styleForCheck(status, conclusion string, styles Styles) lipgloss.Style {
+	switch status {
+	case "completed":
+		switch conclusion {
+		case "success":
+			return styles.Success
+		case "failure", "timed_out":
+			return styles.Failure
+		case "action_required":
+			return styles.Running
+		default:
+			return styles.Queued
+		}
+	case "in_progress":
+		return styles.Running
+	case "queued", "waiting":
+		return styles.Queued
+	default:
+		return styles.Queued
+	}
+}
+
+// formatBranchRunDuration returns a display duration for a standalone run header.
+func formatBranchRunDuration(run ghclient.BranchRunData) string {
+	if !run.RunStartedAt.IsZero() {
+		switch run.Status {
+		case "in_progress", "queued", "waiting":
+			runtime := time.Since(run.RunStartedAt)
+			if runtime > 0 {
+				return timing.FormatDuration(runtime)
+			}
+		}
+	}
+	return "-"
+}
+
+// formatBranchJobName formats a job name as "Workflow / Job" or "Job".
+func formatBranchJobName(job ghclient.CheckRunInfo) string {
+	if job.WorkflowName != "" {
+		return fmt.Sprintf("%s / %s", job.WorkflowName, job.Name)
+	}
+	return job.Name
+}
+
+// formatBranchJobNameTruncate truncates a job name to maxWidth with an ellipsis.
+func formatBranchJobNameTruncate(job ghclient.CheckRunInfo, maxWidth int) string {
+	name := formatBranchJobName(job)
+	if runewidth.StringWidth(name) <= maxWidth {
+		return name
+	}
+	return runewidth.Truncate(name, maxWidth, "…")
+}
+
+// formatBranchJobDuration returns a display duration for a single job.
+func formatBranchJobDuration(job ghclient.CheckRunInfo) string {
+	switch job.Status {
+	case "completed":
+		if job.StartedAt != nil && job.CompletedAt != nil {
+			d := job.CompletedAt.Sub(*job.StartedAt)
+			if d > 0 {
+				return timing.FormatDuration(d)
+			}
+		}
+		return "-"
+	case "in_progress":
+		if job.StartedAt != nil {
+			runtime := time.Since(*job.StartedAt)
+			if runtime > 0 {
+				return timing.FormatDuration(runtime)
+			}
+		}
+		return "-"
+	default:
+		return "-"
+	}
+}
+
+// branchRunColumnWidths holds widths for the two-column branch-run job layout.
+type branchRunColumnWidths struct {
+	nameWidth     int
+	durationWidth int
+}
+
+// calculateBranchRunColumnWidths scans jobs to size the name and duration columns.
+func calculateBranchRunColumnWidths(jobs []ghclient.CheckRunInfo) branchRunColumnWidths {
+	const (
+		minNameWidth     = 20
+		maxNameWidth     = 60
+		minDurationWidth = 5
+	)
+
+	widths := branchRunColumnWidths{
+		nameWidth:     minNameWidth,
+		durationWidth: minDurationWidth,
+	}
+
+	for _, job := range jobs {
+		name := formatBranchJobName(job)
+		nameLen := runewidth.StringWidth(name)
+		if nameLen > widths.nameWidth && nameLen <= maxNameWidth {
+			widths.nameWidth = nameLen
+		} else if nameLen > maxNameWidth {
+			widths.nameWidth = maxNameWidth
+		}
+
+		durationText := formatBranchJobDuration(job)
+		if runewidth.StringWidth(durationText) > widths.durationWidth {
+			widths.durationWidth = runewidth.StringWidth(durationText)
+		}
+	}
+
+	return widths
+}
+
+// groupBranchRunsByBranch groups standalone runs by their HeadBranch.
+func (m RepoModel) groupBranchRunsByBranch() map[string][]ghclient.BranchRunData {
+	groups := make(map[string][]ghclient.BranchRunData)
+	for _, run := range m.standaloneRuns {
+		branch := run.HeadBranch
+		if branch == "" {
+			branch = "(unknown)"
+		}
+		groups[branch] = append(groups[branch], run)
+	}
+	return groups
+}
+
+// sortedBranchNames returns branch names sorted alphabetically for stable rendering.
+func sortedBranchNames(groups map[string][]ghclient.BranchRunData) []string {
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// pluralS returns "s" when n != 1, else "".
+func pluralS(n int) string {
+	if n != 1 {
+		return "s"
+	}
+	return ""
+}

--- a/internal/tui/runmodel.go
+++ b/internal/tui/runmodel.go
@@ -27,6 +27,11 @@ type RunModel struct {
 
 	// Rate limiting
 	rateLimitRemaining int
+	// fetchReceived is true after the first successful API response that
+	// populated rateLimitRemaining. Before that, rateLimitRemaining is the
+	// Go zero value (0) and the view must not render a misleading
+	// "[Rate limit: 0 remaining]" indicator or trigger backoff.
+	fetchReceived bool
 
 	// UI state
 	spinner         spinner.Model

--- a/internal/tui/runupdate.go
+++ b/internal/tui/runupdate.go
@@ -73,7 +73,9 @@ func (m RunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case RunTickMsg:
-		if m.rateLimitRemaining < rateBackoffThreshold {
+		// Gate backoff on fetchReceived so the zero-value rateLimitRemaining
+		// (0) before the first successful response doesn't suppress fetches.
+		if m.fetchReceived && m.rateLimitRemaining < rateBackoffThreshold {
 			debug.Log("rate limit backoff (run)", "remaining", m.rateLimitRemaining, "threshold", rateBackoffThreshold)
 			return m, runTick(m.refreshInterval*3)
 		}
@@ -118,6 +120,7 @@ func (m *RunModel) handleRunJobsUpdate(msg RunJobsUpdateMsg) (tea.Model, tea.Cmd
 	m.jobs = msg.Jobs
 	SortRunJobs(m.jobs)
 	m.rateLimitRemaining = msg.RateLimitRemaining
+	m.fetchReceived = true
 	m.lastUpdate = time.Now()
 	m.err = nil
 

--- a/internal/tui/runview.go
+++ b/internal/tui/runview.go
@@ -77,6 +77,8 @@ func (m RunModel) View() tea.View {
 	b.WriteString("\n")
 
 	if m.rateLimitRemaining < minRateLimitForFetch {
+		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+	} else if m.rateLimitRemaining < rateWarningThreshold {
 		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
 	}
 

--- a/internal/tui/runview.go
+++ b/internal/tui/runview.go
@@ -76,10 +76,16 @@ func (m RunModel) View() tea.View {
 
 	b.WriteString("\n")
 
-	if m.rateLimitRemaining < minRateLimitForFetch {
-		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
-	} else if m.rateLimitRemaining < rateWarningThreshold {
-		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+	// Two-tier rate-limit indicator: red under minRateLimitForFetch, yellow
+	// under rateWarningThreshold. Only render once we've actually received a
+	// response — before that, rateLimitRemaining is the Go zero value (0) and
+	// showing "[Rate limit: 0 remaining]" in red would be misleading.
+	if m.fetchReceived {
+		if m.rateLimitRemaining < minRateLimitForFetch {
+			b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		} else if m.rateLimitRemaining < rateWarningThreshold {
+			b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		}
 	}
 
 	b.WriteString("\n")

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -85,8 +85,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case TickMsg:
-		// Check rate limit before polling
-		if m.rateLimitRemaining < rateBackoffThreshold {
+		// Check rate limit before polling. Gate on fetchReceived so the
+		// zero-value rateLimitRemaining (0) before the first successful
+		// response doesn't suppress the fetch that would clear that state.
+		if m.fetchReceived && m.rateLimitRemaining < rateBackoffThreshold {
 			debug.Log("rate limit backoff", "remaining", m.rateLimitRemaining, "threshold", rateBackoffThreshold)
 			// Back off if rate limited
 			return m, tick(m.refreshInterval * 3)
@@ -263,6 +265,7 @@ func (m *Model) handleChecksUpdate(msg ChecksUpdateMsg) (tea.Model, tea.Cmd) {
 	m.checkRuns = msg.CheckRuns
 	SortCheckRuns(m.checkRuns)
 	m.rateLimitRemaining = msg.RateLimitRemaining
+	m.fetchReceived = true
 	m.lastUpdate = time.Now()
 	m.err = nil
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -101,6 +101,8 @@ func (m Model) View() tea.View {
 	}
 
 	if m.rateLimitRemaining < minRateLimitForFetch {
+		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+	} else if m.rateLimitRemaining < rateWarningThreshold {
 		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -100,10 +100,16 @@ func (m Model) View() tea.View {
 		b.WriteString("\n")
 	}
 
-	if m.rateLimitRemaining < minRateLimitForFetch {
-		b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
-	} else if m.rateLimitRemaining < rateWarningThreshold {
-		b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+	// Two-tier rate-limit indicator: red under minRateLimitForFetch, yellow
+	// under rateWarningThreshold. Only render once we've actually received a
+	// response — before that, rateLimitRemaining is the Go zero value (0) and
+	// showing "[Rate limit: 0 remaining]" in red would be misleading.
+	if m.fetchReceived {
+		if m.rateLimitRemaining < minRateLimitForFetch {
+			b.WriteString(m.styles.Failure.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		} else if m.rateLimitRemaining < rateWarningThreshold {
+			b.WriteString(m.styles.Running.Render(fmt.Sprintf("  [Rate limit: %d remaining]", m.rateLimitRemaining)))
+		}
 	}
 
 	b.WriteString("\n")

--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ type runMode int
 
 const (
 	modePR   runMode = iota // Watch a PR's checks
-	modeRun                  // Watch an Actions workflow run
-	modeRepo                 // Watch all active workflows on a repo persistently
+	modeRun                 // Watch an Actions workflow run
+	modeRepo                // Watch all active workflows on a repo persistently
 )
 
 // runArgs holds the parsed arguments for either mode.
@@ -279,8 +279,14 @@ func runRepoMode(ctx context.Context, cfg *config.Config, styles tui.Styles, own
 		return 1
 	}
 
-	if m, ok := finalModel.(tui.RepoModel); ok {
-		return m.ExitCode()
+	// RepoModel.Update can return either a value or pointer RepoModel
+	// (the per-message handlers use pointer receivers), so assert on the
+	// ExitCode method rather than a concrete type to handle both forms.
+	type exitCoder interface {
+		ExitCode() int
+	}
+	if ec, ok := finalModel.(exitCoder); ok {
+		return ec.ExitCode()
 	}
 
 	return 0

--- a/main.go
+++ b/main.go
@@ -27,10 +27,22 @@ var quickFlag bool
 var debugFlag bool
 var repoFlag string
 
+// repoFlagAutoSentinel is the NoOptDefVal for --repo: when the user passes
+// --repo with no value, pflag fills repoFlag with this sentinel so we can
+// distinguish "no value given (auto-detect)" from "value given explicitly".
+// Any string that can't be parsed as owner/repo or a GitHub URL works; we
+// use a single underscore which is invalid in both GitHub owner and repo names.
+const repoFlagAutoSentinel = "_"
+
 func init() {
 	rootCmd.Flags().BoolVarP(&quickFlag, "quick", "q", false, "Skip fetching historical average runtimes")
 	rootCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false, "Log suppressed errors and internal state to a file")
-	rootCmd.Flags().StringVar(&repoFlag, "repo", "", "Watch all active workflows on a repo persistently (owner/repo or URL)")
+	rootCmd.Flags().StringVar(&repoFlag, "repo", "", "Watch all active workflows on a repo persistently (owner/repo or URL; bare --repo auto-detects from current git remote)")
+	// Allow `--repo` with no value: pflag fills repoFlag with this sentinel
+	// so resolveRepoArg can distinguish "no value given (auto-detect)" from
+	// "value given explicitly". Any string invalid as owner/repo or a GitHub
+	// URL works; "_" is invalid in both GitHub owner and repo names.
+	rootCmd.Flags().Lookup("repo").NoOptDefVal = repoFlagAutoSentinel
 }
 
 var rootCmd = &cobra.Command{
@@ -47,6 +59,7 @@ Also supports watching GitHub Actions runs by passing a run URL:
   gh-observer https://github.com/owner/repo/actions/runs/123456789
 
 Use --repo to persistently watch all active workflows on a repository:
+  gh-observer --repo              # auto-detect from current git remote
   gh-observer --repo owner/repo
   gh-observer --repo https://github.com/owner/repo`,
 	Args: cobra.MaximumNArgs(1),
@@ -87,8 +100,19 @@ func run(cmd *cobra.Command, args []string) int {
 	}
 
 	repoMode := cmd.Flags().Changed("repo")
+	bareRepoFlag := repoMode && repoFlag == repoFlagAutoSentinel
 
 	// Validate flag combinations early.
+	//
+	// With NoOptDefVal set on --repo, a bare token after `--repo` is not
+	// consumed by the flag (only `--repo=VALUE` is). So accept the form
+	// `gh-observer --repo owner/repo` by treating a single trailing
+	// positional as the repo value when --repo was given bare. The
+	// `--repo=VALUE` form still rejects positionals.
+	if bareRepoFlag && len(args) == 1 {
+		repoFlag = args[0]
+		args = nil
+	}
 	if repoMode && len(args) > 0 {
 		fmt.Fprintf(os.Stderr, "Error: --repo flag cannot be used with positional arguments\n")
 		return 1
@@ -153,9 +177,11 @@ func run(cmd *cobra.Command, args []string) int {
 }
 
 // resolveRepoArg resolves the owner/repo from the --repo flag value.
-// If the value is empty, it auto-detects the current repo from git remote.
+// If the value is empty or the auto-detect sentinel (passed by pflag when
+// --repo is given with no value), it auto-detects the current repo from the
+// git remote. Otherwise it parses the value as owner/repo or a GitHub URL.
 func resolveRepoArg(val string) (string, string, error) {
-	if val != "" {
+	if val != "" && val != repoFlagAutoSentinel {
 		return ghclient.ParseRepoArg(val)
 	}
 	owner, repo, err := ghclient.GetCurrentRepo()

--- a/main.go
+++ b/main.go
@@ -25,10 +25,12 @@ func main() {
 
 var quickFlag bool
 var debugFlag bool
+var repoFlag string
 
 func init() {
 	rootCmd.Flags().BoolVarP(&quickFlag, "quick", "q", false, "Skip fetching historical average runtimes")
 	rootCmd.Flags().BoolVarP(&debugFlag, "debug", "d", false, "Log suppressed errors and internal state to a file")
+	rootCmd.Flags().StringVar(&repoFlag, "repo", "", "Watch all active workflows on a repo persistently (owner/repo or URL)")
 }
 
 var rootCmd = &cobra.Command{
@@ -42,10 +44,14 @@ Supports watching checks on external repositories by passing a full PR URL:
   gh-observer https://github.com/owner/repo/pull/123
 
 Also supports watching GitHub Actions runs by passing a run URL:
-  gh-observer https://github.com/owner/repo/actions/runs/123456789`,
+  gh-observer https://github.com/owner/repo/actions/runs/123456789
+
+Use --repo to persistently watch all active workflows on a repository:
+  gh-observer --repo owner/repo
+  gh-observer --repo https://github.com/owner/repo`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		exitCode := run(args)
+		exitCode := run(cmd, args)
 		os.Exit(exitCode)
 	},
 }
@@ -56,18 +62,19 @@ type runMode int
 const (
 	modePR   runMode = iota // Watch a PR's checks
 	modeRun                  // Watch an Actions workflow run
+	modeRepo                 // Watch all active workflows on a repo persistently
 )
 
 // runArgs holds the parsed arguments for either mode.
 type runArgs struct {
-	mode       runMode
-	owner      string
-	repo       string
-	prNumber   int
-	runID      int64
+	mode     runMode
+	owner    string
+	repo     string
+	prNumber int
+	runID    int64
 }
 
-func run(args []string) int {
+func run(cmd *cobra.Command, args []string) int {
 	ctx := context.Background()
 
 	if debugFlag {
@@ -77,6 +84,22 @@ func run(args []string) int {
 		}
 		defer debug.Close()
 		fmt.Fprintf(os.Stderr, "Debug log: %s\n", debug.LogPath())
+	}
+
+	repoMode := cmd.Flags().Changed("repo")
+
+	// Validate flag combinations early.
+	if repoMode && len(args) > 0 {
+		fmt.Fprintf(os.Stderr, "Error: --repo flag cannot be used with positional arguments\n")
+		return 1
+	}
+	if repoMode && quickFlag {
+		fmt.Fprintf(os.Stderr, "Error: --repo flag cannot be used with --quick\n")
+		return 1
+	}
+	if repoMode && !term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Fprintf(os.Stderr, "Error: --repo flag requires an interactive terminal\n")
+		return 1
 	}
 
 	// Load configuration
@@ -93,6 +116,16 @@ func run(args []string) int {
 		cfg.Colors.Running,
 		cfg.Colors.Queued,
 	)
+
+	// Handle repo mode up front: it has its own arg resolution and entry point.
+	if repoMode {
+		owner, repo, err := resolveRepoArg(repoFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return 1
+		}
+		return runRepoMode(ctx, cfg, styles, owner, repo)
+	}
 
 	// Parse arguments
 	parsed, err := parseArgs(args)
@@ -117,6 +150,19 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "Unknown mode\n")
 		return 1
 	}
+}
+
+// resolveRepoArg resolves the owner/repo from the --repo flag value.
+// If the value is empty, it auto-detects the current repo from git remote.
+func resolveRepoArg(val string) (string, string, error) {
+	if val != "" {
+		return ghclient.ParseRepoArg(val)
+	}
+	owner, repo, err := ghclient.GetCurrentRepo()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to detect current repo: %v\nUse --repo owner/repo to specify explicitly", err)
+	}
+	return owner, repo, nil
 }
 
 // parseArgs determines whether the argument is a PR number, PR URL, or Actions run URL.
@@ -205,6 +251,35 @@ func runActionsMode(ctx context.Context, token string, parsed runArgs, cfg *conf
 	}
 
 	if m, ok := finalModel.(tui.RunModel); ok {
+		return m.ExitCode()
+	}
+
+	return 0
+}
+
+// runRepoMode handles persistent watching of all active workflows on a repo.
+// It is always interactive (snapshot mode is rejected earlier in run()).
+func runRepoMode(ctx context.Context, cfg *config.Config, styles tui.Styles, owner, repo string) int {
+	token, err := ghclient.GetToken()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get GitHub token: %v\n", err)
+		return 1
+	}
+
+	model := tui.NewRepoModel(
+		ctx, token, owner, repo,
+		cfg.RepoRefreshInterval, styles, cfg.EnableLinks,
+		cfg.FadeSuccess, cfg.FadeFailure,
+	)
+
+	p := tea.NewProgram(model)
+	finalModel, err := p.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error running TUI: %v\n", err)
+		return 1
+	}
+
+	if m, ok := finalModel.(tui.RepoModel); ok {
 		return m.ExitCode()
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,8 +30,13 @@ var repoFlag string
 // repoFlagAutoSentinel is the NoOptDefVal for --repo: when the user passes
 // --repo with no value, pflag fills repoFlag with this sentinel so we can
 // distinguish "no value given (auto-detect)" from "value given explicitly".
-// Any string that can't be parsed as owner/repo or a GitHub URL works; we
-// use a single underscore which is invalid in both GitHub owner and repo names.
+//
+// The required properties are (a) not parseable as "owner/repo" or a
+// GitHub URL, and (b) not something a user would type on purpose. A single
+// underscore "_" satisfies both: ParseRepoArg in internal/github/repo.go
+// explicitly rejects all-underscore segments (see isAllUnderscoreSegment),
+// so `gh-observer --repo _` errors cleanly as an invalid argument rather
+// than being mistaken for auto-detect or treated as a literal owner/repo.
 const repoFlagAutoSentinel = "_"
 
 func init() {
@@ -40,8 +45,10 @@ func init() {
 	rootCmd.Flags().StringVar(&repoFlag, "repo", "", "Watch all active workflows on a repo persistently (owner/repo or URL; bare --repo auto-detects from current git remote)")
 	// Allow `--repo` with no value: pflag fills repoFlag with this sentinel
 	// so resolveRepoArg can distinguish "no value given (auto-detect)" from
-	// "value given explicitly". Any string invalid as owner/repo or a GitHub
-	// URL works; "_" is invalid in both GitHub owner and repo names.
+	// "value given explicitly". The sentinel must be not parseable as
+	// owner/repo or a GitHub URL and not something a user would type on
+	// purpose; ParseRepoArg explicitly rejects all-underscore segments so
+	// "_" works and `--repo _` errors cleanly.
 	rootCmd.Flags().Lookup("repo").NoOptDefVal = repoFlagAutoSentinel
 }
 


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🔭 [src] add --repo watcher mode
- first round of debugging rate limiting
- round 2 of fixes for rate limiting
- rate-limiting is much better, fixes #269
- fixes for copilot code review by glp-5.2/opencode
- fixes for copilot code review - let --repo work on the current repo without an argument
- update README for repo mode
- fix repo-mode rate-limit and fetch-error handling per Copilot review

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)



