### PR TITLE
💊 [gha] .intoto.jsonl is not a spelling mistake for codespell

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = intoto


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 💊 [gha] .intoto.jsonl is not a spelling mistake for codespell

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
