### PR TITLE
🐘 [src] default to DCO to 1s historical average and make configurable with arbitrary fill-in values, fixes #322

### DIFF
--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -17,3 +17,14 @@ colors:
   failure: 9   # Red - completed with failure
   running: 11  # Yellow - currently in progress
   queued: 8    # Gray - waiting to start
+
+# Presumed historical averages for checks that have no Actions workflow run
+# to fetch history from (e.g. external GitHub App checks like DCO provided by
+# Probot). When such a check appears in the check list, the configured duration
+# is shown in the HistAvg column instead of a blank cell. Real history always
+# wins: if a workflow run is later found for a check name, that real average
+# replaces the presumed value. Keys are matched against the check Name field
+# case-insensitively (viper lowercases config map keys, so "DCO" and "dco" are
+# equivalent). Durations use Go time.ParseDuration syntax.
+presumed_averages:
+  DCO: 1s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,12 @@ type ColorConfig struct {
 }
 
 type Config struct {
-	RefreshInterval     time.Duration    `mapstructure:"refresh_interval"`
-	RepoRefreshInterval time.Duration    `mapstructure:"repo_refresh_interval"`
-	FadeSuccess         time.Duration    `mapstructure:"fade_success"`
-	FadeFailure         time.Duration    `mapstructure:"fade_failure"`
-	Colors              ColorConfig      `mapstructure:"colors"`
-	EnableLinks         bool            `mapstructure:"enable_links"`
+	RefreshInterval     time.Duration     `mapstructure:"refresh_interval"`
+	RepoRefreshInterval time.Duration     `mapstructure:"repo_refresh_interval"`
+	FadeSuccess         time.Duration     `mapstructure:"fade_success"`
+	FadeFailure         time.Duration     `mapstructure:"fade_failure"`
+	Colors              ColorConfig       `mapstructure:"colors"`
+	EnableLinks         bool              `mapstructure:"enable_links"`
 	PresumedAverages    map[string]string `mapstructure:"presumed_averages"`
 }
 
@@ -70,7 +70,8 @@ func Load() (*Config, error) {
 // are silently dropped (matching the lenient approach used elsewhere in the
 // config system). The returned map is never nil when cfg.PresumedAverages is
 // populated. The default DCO entry is included automatically via viper
-// defaults, so callers can always look up "DCO" in the result.
+// defaults; note that viper lowercases map keys, so the default key is "dco"
+// and lookups should be case-insensitive (as ApplyPresumedAverages does).
 func (c *Config) PresumedAveragesDurations() map[string]time.Duration {
 	if len(c.PresumedAverages) == 0 {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,13 @@ type ColorConfig struct {
 }
 
 type Config struct {
-	RefreshInterval     time.Duration `mapstructure:"refresh_interval"`
-	RepoRefreshInterval time.Duration `mapstructure:"repo_refresh_interval"`
-	FadeSuccess         time.Duration `mapstructure:"fade_success"`
-	FadeFailure         time.Duration `mapstructure:"fade_failure"`
-	Colors              ColorConfig   `mapstructure:"colors"`
-	EnableLinks         bool          `mapstructure:"enable_links"`
+	RefreshInterval     time.Duration    `mapstructure:"refresh_interval"`
+	RepoRefreshInterval time.Duration    `mapstructure:"repo_refresh_interval"`
+	FadeSuccess         time.Duration    `mapstructure:"fade_success"`
+	FadeFailure         time.Duration    `mapstructure:"fade_failure"`
+	Colors              ColorConfig      `mapstructure:"colors"`
+	EnableLinks         bool            `mapstructure:"enable_links"`
+	PresumedAverages    map[string]string `mapstructure:"presumed_averages"`
 }
 
 func Load() (*Config, error) {
@@ -39,6 +40,7 @@ func Load() (*Config, error) {
 	v.SetDefault("colors.running", 11) // Yellow
 	v.SetDefault("colors.queued", 8)   // Gray
 	v.SetDefault("enable_links", true)
+	v.SetDefault("presumed_averages.DCO", "1s")
 
 	// Config location: ~/.config/gh-observer/config.yaml
 	home, err := os.UserHomeDir()
@@ -61,4 +63,26 @@ func Load() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// PresumedAveragesDurations resolves the raw presumed_averages string map
+// into a map of time.Duration keyed by check Name. Invalid duration strings
+// are silently dropped (matching the lenient approach used elsewhere in the
+// config system). The returned map is never nil when cfg.PresumedAverages is
+// populated. The default DCO entry is included automatically via viper
+// defaults, so callers can always look up "DCO" in the result.
+func (c *Config) PresumedAveragesDurations() map[string]time.Duration {
+	if len(c.PresumedAverages) == 0 {
+		return nil
+	}
+	result := make(map[string]time.Duration, len(c.PresumedAverages))
+	for name, raw := range c.PresumedAverages {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			debug.Log("presumed_averages parse error", "name", name, "value", raw, "err", err)
+			continue
+		}
+		result[name] = d
+	}
+	return result
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,9 +227,9 @@ func TestLoad_DurationParsing(t *testing.T) {
 				t.Fatalf("Load() returned error: %v", err)
 			}
 
-	if cfg.RefreshInterval != tt.want {
-			t.Errorf("RefreshInterval = %v, want %v", cfg.RefreshInterval, tt.want)
-		}
+			if cfg.RefreshInterval != tt.want {
+				t.Errorf("RefreshInterval = %v, want %v", cfg.RefreshInterval, tt.want)
+			}
 		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -226,9 +227,115 @@ func TestLoad_DurationParsing(t *testing.T) {
 				t.Fatalf("Load() returned error: %v", err)
 			}
 
-			if cfg.RefreshInterval != tt.want {
-				t.Errorf("RefreshInterval = %v, want %v", cfg.RefreshInterval, tt.want)
-			}
+	if cfg.RefreshInterval != tt.want {
+			t.Errorf("RefreshInterval = %v, want %v", cfg.RefreshInterval, tt.want)
+		}
 		})
 	}
+}
+
+func TestLoad_PresumedAveragesDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	dur := cfg.PresumedAveragesDurations()
+	if dur == nil {
+		t.Fatal("PresumedAveragesDurations() = nil, want map with DCO default")
+	}
+	// Viper lowercases map keys, so look up case-insensitively.
+	var dco time.Duration
+	found := false
+	for name, d := range dur {
+		if strings.EqualFold(name, "DCO") {
+			dco = d
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("PresumedAveragesDurations() = %v, want a DCO entry", dur)
+	}
+	if dco != 1*time.Second {
+		t.Errorf("DCO presumed average = %v, want 1s", dco)
+	}
+}
+
+func TestLoad_PresumedAveragesCustom(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "gh-observer")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configContent := `presumed_averages:
+  DCO: 2s
+  WIP: 5s
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	dur := cfg.PresumedAveragesDurations()
+	if d := lookupCI(dur, "DCO"); d != 2*time.Second {
+		t.Errorf("PresumedAveragesDurations()[DCO] = %v, want 2s (custom value)", d)
+	}
+	if d := lookupCI(dur, "WIP"); d != 5*time.Second {
+		t.Errorf("PresumedAveragesDurations()[WIP] = %v, want 5s", d)
+	}
+}
+
+func TestLoad_PresumedAveragesInvalidDropped(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "gh-observer")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configContent := `presumed_averages:
+  DCO: 1s
+  Broken: not-a-duration
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	dur := cfg.PresumedAveragesDurations()
+	if d := lookupCI(dur, "DCO"); d != 1*time.Second {
+		t.Errorf("PresumedAveragesDurations()[DCO] = %v, want 1s", d)
+	}
+	if d := lookupCI(dur, "Broken"); d != 0 {
+		t.Errorf("PresumedAveragesDurations()[Broken] should be dropped, got %v", d)
+	}
+}
+
+// lookupCI looks up a key in a duration map case-insensitively, returning
+// zero if not found. Viper lowercases map keys, so config tests must use a
+// case-insensitive lookup to validate user-facing key names.
+func lookupCI(m map[string]time.Duration, key string) time.Duration {
+	for k, v := range m {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return 0
 }

--- a/internal/github/history.go
+++ b/internal/github/history.go
@@ -358,13 +358,28 @@ func DiscoverAdvSecWorkflows(
 	return advSecMatchWorkflow, workflowIDsToFetch
 }
 
+// githubHostedURLRegexp matches DetailsURLs that point at a GitHub-hosted
+// Actions run (either a full run page or a specific job). AdvSec checks use
+// /runs/<id> URLs, and some Actions checks use /actions/runs/<id> without the
+// trailing /job/<id>. Both are GitHub-hosted, so they are not "external app"
+// checks even when ParseRunIDFromURL (which requires /job/) cannot recover a
+// run ID from them. Treating them as external would let a user-supplied
+// presumed average shadow the real history that AdvSec aliasing later writes.
+var githubHostedURLRegexp = regexp.MustCompile(`^https?://github\.com/[^/]+/[^/]+/(actions/runs/|runs/)`)
+
 // IsExternalAppCheck reports whether a check run is from an external (non-GitHub
 // Actions) app — i.e., it has no WorkflowRunID and no WorkflowID, but has both
-// an AppName and a DetailsURL that does not point at an Actions run. The DCO app
-// provided by Probot is the canonical example; its DetailsURL points off-site
-// (https://probot.github.io/apps/dco/) so ParseRunIDFromURL cannot recover a run
-// ID and history can never be fetched for it. Such checks are candidates for a
-// presumed average (see ApplyPresumedAverages).
+// an AppName and a DetailsURL that does not point at a GitHub-hosted Actions or
+// AdvSec run. The DCO app provided by Probot is the canonical example; its
+// DetailsURL points off-site (https://probot.github.io/apps/dco/) so neither
+// ParseRunIDFromURL nor githubHostedURLRegexp can recover a run ID and history
+// can never be fetched for it. Such checks are candidates for a presumed
+// average (see ApplyPresumedAverages).
+//
+// GitHub-hosted URLs (actions/runs/<id>, actions/runs/<id>/job/<id>, and AdvSec
+// runs/<id>) are treated as non-external so that AdvSec aliasing in the TUI
+// (which writes real history into jobAverages keyed by the check name) is not
+// blocked by a presumed average having already taken the slot.
 func IsExternalAppCheck(cr CheckRunInfo) bool {
 	if cr.WorkflowRunID > 0 || cr.WorkflowID > 0 {
 		return false
@@ -373,6 +388,9 @@ func IsExternalAppCheck(cr CheckRunInfo) bool {
 		return false
 	}
 	if _, err := ParseRunIDFromURL(cr.DetailsURL); err == nil {
+		return false
+	}
+	if githubHostedURLRegexp.MatchString(cr.DetailsURL) {
 		return false
 	}
 	return true

--- a/internal/github/history.go
+++ b/internal/github/history.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fini-net/gh-observer/internal/debug"
@@ -355,4 +356,66 @@ func DiscoverAdvSecWorkflows(
 	}
 
 	return advSecMatchWorkflow, workflowIDsToFetch
+}
+
+// IsExternalAppCheck reports whether a check run is from an external (non-GitHub
+// Actions) app — i.e., it has no WorkflowRunID and no WorkflowID, but has both
+// an AppName and a DetailsURL that does not point at an Actions run. The DCO app
+// provided by Probot is the canonical example; its DetailsURL points off-site
+// (https://probot.github.io/apps/dco/) so ParseRunIDFromURL cannot recover a run
+// ID and history can never be fetched for it. Such checks are candidates for a
+// presumed average (see ApplyPresumedAverages).
+func IsExternalAppCheck(cr CheckRunInfo) bool {
+	if cr.WorkflowRunID > 0 || cr.WorkflowID > 0 {
+		return false
+	}
+	if cr.AppName == "" || cr.DetailsURL == "" {
+		return false
+	}
+	if _, err := ParseRunIDFromURL(cr.DetailsURL); err == nil {
+		return false
+	}
+	return true
+}
+
+// ApplyPresumedAverages injects presumed historical durations for checks that
+// can never have real history (external GitHub App checks like DCO that have no
+// Actions workflow run). For each check Name in presumedAverages that (a) is
+// not already present in jobAverages and (b) appears in checkRuns as an
+// external app check, the presumed duration is written into jobAverages. The
+// jobAverages map is mutated in place; if it is nil it is left untouched.
+//
+// Matching is case-insensitive on the check Name to absorb viper's automatic
+// lowercasing of map keys (the default "DCO" is stored as "dco"). The
+// canonical check Name (preserving the original case from GitHub) is used as
+// the jobAverages key so the rest of the TUI lookup continues to work.
+//
+// This lets the TUI show a sensible ETA (e.g. "1s" for DCO) instead of a blank
+// HistAvg cell, without making any extra API calls.
+func ApplyPresumedAverages(
+	jobAverages map[string]time.Duration,
+	checkRuns []CheckRunInfo,
+	presumedAverages map[string]time.Duration,
+) {
+	if len(presumedAverages) == 0 || jobAverages == nil {
+		return
+	}
+	// Build a case-insensitive lookup so viper's lowercased map keys still
+	// match the canonical check Name from the GitHub API.
+	lower := make(map[string]time.Duration, len(presumedAverages))
+	for name, dur := range presumedAverages {
+		lower[strings.ToLower(name)] = dur
+	}
+	for _, cr := range checkRuns {
+		if !IsExternalAppCheck(cr) {
+			continue
+		}
+		if _, exists := jobAverages[cr.Name]; exists {
+			continue
+		}
+		if dur, ok := lower[strings.ToLower(cr.Name)]; ok {
+			jobAverages[cr.Name] = dur
+			debug.Log("presumed average applied", "check_name", cr.Name, "duration", dur)
+		}
+	}
 }

--- a/internal/github/history_test.go
+++ b/internal/github/history_test.go
@@ -664,6 +664,14 @@ func TestApplyPresumedAverages(t *testing.T) {
 		AppName:    "GitHub Advanced Security",
 		DetailsURL: "https://github.com/owner/repo/runs/73263098935",
 	}
+	// external-but-not-in-map uses an off-site URL so IsExternalAppCheck
+	// classifies it as external (GitHub-hosted /runs/ URLs are non-external
+	// after the githubHostedURLRegexp fix).
+	externalNotInMap := CheckRunInfo{
+		Name:       "Worfload Bot",
+		AppName:    "Worfload",
+		DetailsURL: "https://example.com/worfload/status",
+	}
 
 	t.Run("injects presumed average for DCO", func(t *testing.T) {
 		jobAverages := map[string]time.Duration{}
@@ -689,10 +697,10 @@ func TestApplyPresumedAverages(t *testing.T) {
 	t.Run("skips check names not in presumed map", func(t *testing.T) {
 		jobAverages := map[string]time.Duration{}
 		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
-		// CodeQL is an external app check but not in the presumed map
-		ApplyPresumedAverages(jobAverages, []CheckRunInfo{codeQLAdvSec}, presumed)
-		if _, present := jobAverages["CodeQL"]; present {
-			t.Errorf("jobAverages[CodeQL] should not be set, got %v", jobAverages["CodeQL"])
+		// externalNotInMap is external but not in the presumed map
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{externalNotInMap}, presumed)
+		if _, present := jobAverages["Worfload Bot"]; present {
+			t.Errorf("jobAverages[Worfload Bot] should not be set, got %v", jobAverages["Worfload Bot"])
 		}
 	})
 
@@ -716,6 +724,18 @@ func TestApplyPresumedAverages(t *testing.T) {
 		ApplyPresumedAverages(jobAverages, []CheckRunInfo{build}, presumed)
 		if len(jobAverages) != 0 {
 			t.Errorf("jobAverages should be empty, got %v", jobAverages)
+		}
+	})
+
+	t.Run("AdvSec /runs/ URL is not external, presumed average does not apply", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{}
+		// A presumed average for "CodeQL" must not be injected because the
+		// AdvSec /runs/ URL is GitHub-hosted and should be handled by AdvSec
+		// aliasing instead, not presumed averages.
+		presumed := map[string]time.Duration{"CodeQL": 30 * time.Second}
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{codeQLAdvSec}, presumed)
+		if _, present := jobAverages["CodeQL"]; present {
+			t.Errorf("jobAverages[CodeQL] should not be set for AdvSec /runs/ URL, got %v", jobAverages["CodeQL"])
 		}
 	})
 }

--- a/internal/github/history_test.go
+++ b/internal/github/history_test.go
@@ -559,3 +559,154 @@ func TestFetchWorkflowHistory(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExternalAppCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   CheckRunInfo
+		want bool
+	}{
+		{
+			name: "DCO external app is external",
+			cr: CheckRunInfo{
+				Name:       "DCO",
+				AppName:    "DCO",
+				DetailsURL: "https://probot.github.io/apps/dco/",
+			},
+			want: true,
+		},
+		{
+			name: "GitHub Actions check with WorkflowID is not external",
+			cr: CheckRunInfo{
+				Name:       "build",
+				WorkflowID: 789,
+				DetailsURL: "https://github.com/owner/repo/actions/runs/123/job/456",
+			},
+			want: false,
+		},
+		{
+			name: "GitHub Actions check with WorkflowRunID is not external",
+			cr: CheckRunInfo{
+				Name:          "build",
+				WorkflowRunID: 123,
+				DetailsURL:     "https://github.com/owner/repo/actions/runs/123/job/456",
+			},
+			want: false,
+		},
+		{
+			name: "AdvSec check with parseable Actions run URL is not external",
+			cr: CheckRunInfo{
+				Name:       "CodeQL",
+				AppName:    "GitHub Advanced Security",
+				DetailsURL: "https://github.com/owner/repo/actions/runs/12345678/job/987654321",
+			},
+			want: false,
+		},
+		{
+			name: "AdvSec check with /runs/ URL (no run ID) is external",
+			cr: CheckRunInfo{
+				Name:       "CodeQL",
+				AppName:    "GitHub Advanced Security",
+				DetailsURL: "https://github.com/owner/repo/runs/73263098935",
+			},
+			want: true,
+		},
+		{
+			name: "check with no AppName and no DetailsURL is not external",
+			cr: CheckRunInfo{
+				Name: "lint",
+			},
+			want: false,
+		},
+		{
+			name: "check with only AppName but no DetailsURL is not external (cannot classify)",
+			cr: CheckRunInfo{
+				Name:    "DCO",
+				AppName: "DCO",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsExternalAppCheck(tt.cr)
+			if got != tt.want {
+				t.Errorf("IsExternalAppCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyPresumedAverages(t *testing.T) {
+	dco := CheckRunInfo{
+		Name:       "DCO",
+		AppName:    "DCO",
+		DetailsURL: "https://probot.github.io/apps/dco/",
+	}
+	build := CheckRunInfo{
+		Name:          "build",
+		WorkflowID:    789,
+		WorkflowRunID: 123,
+		DetailsURL:    "https://github.com/owner/repo/actions/runs/123/job/456",
+	}
+	codeQLAdvSec := CheckRunInfo{
+		Name:       "CodeQL",
+		AppName:    "GitHub Advanced Security",
+		DetailsURL: "https://github.com/owner/repo/runs/73263098935",
+	}
+
+	t.Run("injects presumed average for DCO", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{}
+		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{dco, build}, presumed)
+		if jobAverages["DCO"] != 1*time.Second {
+			t.Errorf("jobAverages[DCO] = %v, want 1s", jobAverages["DCO"])
+		}
+		if _, present := jobAverages["build"]; present {
+			t.Errorf("jobAverages[build] should not be set, got %v", jobAverages["build"])
+		}
+	})
+
+	t.Run("does not overwrite existing real history", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{"DCO": 5 * time.Second}
+		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{dco}, presumed)
+		if jobAverages["DCO"] != 5*time.Second {
+			t.Errorf("jobAverages[DCO] = %v, want 5s (should not overwrite existing)", jobAverages["DCO"])
+		}
+	})
+
+	t.Run("skips check names not in presumed map", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{}
+		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
+		// CodeQL is an external app check but not in the presumed map
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{codeQLAdvSec}, presumed)
+		if _, present := jobAverages["CodeQL"]; present {
+			t.Errorf("jobAverages[CodeQL] should not be set, got %v", jobAverages["CodeQL"])
+		}
+	})
+
+	t.Run("no-op when presumed map is empty", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{}
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{dco}, nil)
+		if len(jobAverages) != 0 {
+			t.Errorf("jobAverages should be empty, got %v", jobAverages)
+		}
+	})
+
+	t.Run("no-op when jobAverages is nil", func(t *testing.T) {
+		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
+		// Should not panic
+		ApplyPresumedAverages(nil, []CheckRunInfo{dco}, presumed)
+	})
+
+	t.Run("no-op when no external app checks present", func(t *testing.T) {
+		jobAverages := map[string]time.Duration{}
+		presumed := map[string]time.Duration{"DCO": 1 * time.Second}
+		ApplyPresumedAverages(jobAverages, []CheckRunInfo{build}, presumed)
+		if len(jobAverages) != 0 {
+			t.Errorf("jobAverages should be empty, got %v", jobAverages)
+		}
+	})
+}

--- a/internal/github/history_test.go
+++ b/internal/github/history_test.go
@@ -589,7 +589,7 @@ func TestIsExternalAppCheck(t *testing.T) {
 			cr: CheckRunInfo{
 				Name:          "build",
 				WorkflowRunID: 123,
-				DetailsURL:     "https://github.com/owner/repo/actions/runs/123/job/456",
+				DetailsURL:    "https://github.com/owner/repo/actions/runs/123/job/456",
 			},
 			want: false,
 		},
@@ -603,13 +603,22 @@ func TestIsExternalAppCheck(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "AdvSec check with /runs/ URL (no run ID) is external",
+			name: "AdvSec check with /runs/ URL is not external (GitHub-hosted, handled via aliasing)",
 			cr: CheckRunInfo{
 				Name:       "CodeQL",
 				AppName:    "GitHub Advanced Security",
 				DetailsURL: "https://github.com/owner/repo/runs/73263098935",
 			},
-			want: true,
+			want: false,
+		},
+		{
+			name: "Actions check with /actions/runs/<id> URL (no /job/) is not external (GitHub-hosted)",
+			cr: CheckRunInfo{
+				Name:       "build",
+				AppName:    "GitHub Actions",
+				DetailsURL: "https://github.com/owner/repo/actions/runs/12345678",
+			},
+			want: false,
 		},
 		{
 			name: "check with no AppName and no DetailsURL is not external",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -79,10 +79,17 @@ type Model struct {
 	// historyFetchCompleted is true after at least one discovery cycle
 	// has finished (all pending workflow fetches resolved).
 	historyFetchCompleted bool
+
+	// Presumed historical averages for external GitHub App checks (e.g. DCO)
+	// that can never have real Actions history. Injected into jobAverages by
+	// handleChecksUpdate on each refresh so the HistAvg column shows a value
+	// (e.g. "1s") instead of blank. Configured via config.yaml's
+	// presumed_averages map.
+	presumedAverages map[string]time.Duration
 }
 
 // NewModel creates a new TUI model
-func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool) Model {
+func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool, presumedAverages map[string]time.Duration) Model {
 	s := spinner.New(spinner.WithSpinner(spinner.Dot))
 
 	return Model{
@@ -106,6 +113,7 @@ func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refr
 		pendingWorkflowFetch:    make(map[int64]bool),
 		dispatchedWorkflowFetch: make(map[int64]bool),
 		seenCheckKeys:          make(map[string]bool),
+		presumedAverages:        presumedAverages,
 	}
 }
 

--- a/internal/tui/runmodel.go
+++ b/internal/tui/runmodel.go
@@ -70,10 +70,15 @@ type RunModel struct {
 	// historyFetchCompleted is true after at least one discovery cycle
 	// has finished (all pending workflow fetches resolved).
 	historyFetchCompleted bool
+
+	// Presumed historical averages for external GitHub App checks (e.g. DCO).
+	// See Model.presumedAverages for the full rationale. Run mode rarely has
+	// external app checks, but we apply the same logic for consistency.
+	presumedAverages map[string]time.Duration
 }
 
 // NewRunModel creates a new TUI model for watching a workflow run.
-func NewRunModel(ctx context.Context, token, owner, repo string, runID int64, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool) RunModel {
+func NewRunModel(ctx context.Context, token, owner, repo string, runID int64, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool, presumedAverages map[string]time.Duration) RunModel {
 	s := spinner.New(spinner.WithSpinner(spinner.Dot))
 
 	client, _ := ghclient.NewClientFromToken(token)
@@ -99,6 +104,7 @@ func NewRunModel(ctx context.Context, token, owner, repo string, runID int64, re
 		pendingWorkflowFetch:    make(map[int64]bool),
 		dispatchedWorkflowFetch: make(map[int64]bool),
 		seenJobKeys:             make(map[string]bool),
+		presumedAverages:        presumedAverages,
 	}
 }
 

--- a/internal/tui/runupdate.go
+++ b/internal/tui/runupdate.go
@@ -124,6 +124,11 @@ func (m *RunModel) handleRunJobsUpdate(msg RunJobsUpdateMsg) (tea.Model, tea.Cmd
 	m.lastUpdate = time.Now()
 	m.err = nil
 
+	// Inject presumed historical durations for external GitHub App checks
+	// (e.g. DCO). Run mode jobs are almost always real Actions jobs, but we
+	// apply the same logic for consistency. Idempotent — real history wins.
+	ghclient.ApplyPresumedAverages(m.jobAverages, ghclient.WorkflowJobInfoToCheckRuns(msg.Jobs), m.presumedAverages)
+
 	debug.Log("run jobs update", "count", len(msg.Jobs), "rate_limit_remaining", msg.RateLimitRemaining)
 
 	newJobs := hasNewRunJobs(msg.Jobs, m.seenJobKeys)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -269,6 +269,12 @@ func (m *Model) handleChecksUpdate(msg ChecksUpdateMsg) (tea.Model, tea.Cmd) {
 	m.lastUpdate = time.Now()
 	m.err = nil
 
+	// Inject presumed historical durations for external GitHub App checks
+	// (e.g. DCO) that have no Actions workflow run to fetch history for. This
+	// is idempotent — it only writes when the job name is absent from
+	// m.jobAverages, so real history fetched later always wins.
+	ghclient.ApplyPresumedAverages(m.jobAverages, m.checkRuns, m.presumedAverages)
+
 	if len(msg.CheckRuns) > m.peakCheckCount {
 		m.peakCheckCount = len(msg.CheckRuns)
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1138,3 +1138,77 @@ func TestAdvSecAliasOnRediscovery(t *testing.T) {
 		}
 	})
 }
+
+func TestPresumedAverages(t *testing.T) {
+	dco := ghclient.CheckRunInfo{
+		Name:       "DCO",
+		AppName:    "DCO",
+		Status:     "completed",
+		Conclusion: "success",
+		DetailsURL: "https://probot.github.io/apps/dco/",
+	}
+	build := ghclient.CheckRunInfo{
+		Name:          "build",
+		WorkflowRunID: 100,
+		WorkflowID:    200,
+		Status:        "in_progress",
+		DetailsURL:    "https://github.com/o/r/actions/runs/100/job/1",
+	}
+
+	t.Run("handleChecksUpdate injects presumed DCO average", func(t *testing.T) {
+		m := makeModel()
+		m.rateLimitRemaining = 5000
+		m.firstCheckSeenAt = time.Now().Add(-15 * time.Second)
+		m.presumedAverages = map[string]time.Duration{"DCO": 1 * time.Second}
+
+		msg := ChecksUpdateMsg{
+			CheckRuns:          []ghclient.CheckRunInfo{dco, build},
+			RateLimitRemaining: 5000,
+		}
+		model, _ := m.handleChecksUpdate(msg)
+		result := model.(*Model)
+
+		if result.jobAverages["DCO"] != 1*time.Second {
+			t.Errorf("jobAverages[DCO] = %v, want 1s", result.jobAverages["DCO"])
+		}
+		if _, present := result.jobAverages["build"]; present {
+			t.Errorf("jobAverages[build] should not be presumed-set, got %v", result.jobAverages["build"])
+		}
+	})
+
+	t.Run("handleChecksUpdate does not overwrite real history", func(t *testing.T) {
+		m := makeModel()
+		m.rateLimitRemaining = 5000
+		m.firstCheckSeenAt = time.Now().Add(-15 * time.Second)
+		m.presumedAverages = map[string]time.Duration{"DCO": 1 * time.Second}
+		m.jobAverages = map[string]time.Duration{"DCO": 5 * time.Second}
+
+		msg := ChecksUpdateMsg{
+			CheckRuns:          []ghclient.CheckRunInfo{dco},
+			RateLimitRemaining: 5000,
+		}
+		model, _ := m.handleChecksUpdate(msg)
+		result := model.(*Model)
+
+		if result.jobAverages["DCO"] != 5*time.Second {
+			t.Errorf("jobAverages[DCO] = %v, want 5s (real history should win)", result.jobAverages["DCO"])
+		}
+	})
+
+	t.Run("handleChecksUpdate no-op when presumedAverages is nil", func(t *testing.T) {
+		m := makeModel()
+		m.rateLimitRemaining = 5000
+		m.firstCheckSeenAt = time.Now().Add(-15 * time.Second)
+
+		msg := ChecksUpdateMsg{
+			CheckRuns:          []ghclient.CheckRunInfo{dco},
+			RateLimitRemaining: 5000,
+		}
+		model, _ := m.handleChecksUpdate(msg)
+		result := model.(*Model)
+
+		if _, present := result.jobAverages["DCO"]; present {
+			t.Errorf("jobAverages[DCO] should not be set with nil presumedAverages, got %v", result.jobAverages["DCO"])
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -245,11 +245,11 @@ func runPRMode(ctx context.Context, token string, parsed runArgs, cfg *config.Co
 
 	// Check if running in a terminal
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		return runSnapshot(ctx, token, owner, repo, prNumber, cfg.EnableLinks, quickFlag)
+		return runSnapshot(ctx, token, owner, repo, prNumber, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
 	}
 
 	// Create model
-	model := tui.NewModel(ctx, token, owner, repo, prNumber, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag)
+	model := tui.NewModel(ctx, token, owner, repo, prNumber, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
 
 	// Run TUI
 	p := tea.NewProgram(model)
@@ -272,11 +272,11 @@ func runActionsMode(ctx context.Context, token string, parsed runArgs, cfg *conf
 
 	// Check if running in a terminal
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		return runRunSnapshot(ctx, owner, repo, runID, cfg.EnableLinks, quickFlag)
+		return runRunSnapshot(ctx, owner, repo, runID, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
 	}
 
 	// Create run model
-	model := tui.NewRunModel(ctx, token, owner, repo, runID, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag)
+	model := tui.NewRunModel(ctx, token, owner, repo, runID, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
 
 	// Run TUI
 	p := tea.NewProgram(model)
@@ -329,7 +329,7 @@ func runRepoMode(ctx context.Context, cfg *config.Config, styles tui.Styles, own
 }
 
 // runSnapshot prints a one-time snapshot of PR check status (non-interactive mode)
-func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, enableLinks bool, quick bool) int {
+func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, enableLinks bool, quick bool, presumedAverages map[string]time.Duration) int {
 	client, err := ghclient.NewClient(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create GitHub client: %v\n", err)
@@ -374,6 +374,11 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 		}
 	}
 
+	if jobAverages == nil {
+		jobAverages = make(map[string]time.Duration)
+	}
+	ghclient.ApplyPresumedAverages(jobAverages, checkRuns, presumedAverages)
+
 	widths := tui.CalculateColumnWidths(checkRuns, headCommitTime, jobAverages)
 
 	headerQueue, headerName, headerDuration, headerAvg := tui.FormatHeaderColumns(widths)
@@ -402,7 +407,7 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 }
 
 // runRunSnapshot prints a one-time snapshot of Actions run status (non-interactive mode)
-func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enableLinks bool, quick bool) int {
+func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enableLinks bool, quick bool, presumedAverages map[string]time.Duration) int {
 	token, err := ghclient.GetToken()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get GitHub token: %v\n", err)
@@ -452,6 +457,11 @@ func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enable
 			jobAverages = avgs
 		}
 	}
+
+	if jobAverages == nil {
+		jobAverages = make(map[string]time.Duration)
+	}
+	ghclient.ApplyPresumedAverages(jobAverages, ghclient.WorkflowJobInfoToCheckRuns(jobs), presumedAverages)
 
 	widths := tui.CalculateRunColumnWidths(jobs, jobAverages)
 


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🐘 [src] default to DCO to 1s historical average and make configurable with arbitrary fill-in values, fixes #322
- 🐘 [src] treat GitHub-hosted /actions/runs/ and /runs/ URLs as non-external in IsExternalAppCheck
- fixes for copilot code review

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)


