### PR TITLE
🚣 [go] Bump Go to 1.26.5 for GO-2026-5856 (CVE-2026-42505)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fini-net/gh-observer
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🚣 [go] Bump Go to 1.26.5 for GO-2026-5856 (CVE-2026-42505)

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
