### PR TITLE
⏳ [src] historical averages are weighted toward recent runs, fixes #339

### DIFF
--- a/internal/github/history.go
+++ b/internal/github/history.go
@@ -16,9 +16,10 @@ var runIDRegexp = regexp.MustCompile(`/actions/runs/(\d+)/job/`)
 
 // historyDecayFactor weights recent runs more heavily than older ones in
 // weightedAverage. Each run i (0 = newest) contributes historyDecayFactor^i
-// of the average. 0.7 gives the newest run ~42% of a 10-run average and the
-// oldest ~1%, so a slow run from two weeks ago no longer drags the ETA above
-// where the next run actually lands.
+// of the average. With decay=0.7 the geometric series Σ(0.7^i, i=0..9) ≈ 3.239,
+// so the newest run is ~31% of a 10-run average and the oldest ~1%, meaning a
+// slow run from two weeks ago no longer drags the ETA above where the next run
+// actually lands.
 const historyDecayFactor = 0.7
 
 // ParseRunIDFromURL extracts the workflow run ID from a GitHub Actions details URL.
@@ -192,6 +193,21 @@ func averageJobDurations(
 	// jobs are appended together via ListWorkflowJobs. weightedAverage relies on
 	// this ordering to give the most recent run the largest weight, so any
 	// future refactor that re-shuffles runIDs or durations must preserve it.
+	//
+	// Known limitation: this invariant holds for the FetchWorkflowHistory call
+	// site (one workflow at a time, so runIDs are strictly newest-first), but
+	// NOT for the legacy FetchJobAverages snapshot-mode path, which builds
+	// historicalRunIDs by concatenating each workflow's newest-first runs while
+	// ranging over workflowIDsToFetch (a map, non-deterministic order). When two
+	// workflows in the same PR share a bare job name (e.g. "build", "test"), the
+	// merged per-name slice is "whichever workflow iterated first, newest-first
+	// within that workflow, then the other workflow's runs appended" — not true
+	// chronological newest-first. The decay then biases toward an arbitrary
+	// workflow, nondeterministically across runs. The TUI path is unaffected
+	// because it calls averageJobDurations once per workflow. Sorting runs by
+	// actual timestamp across workflows before weighting would close this gap
+	// (the run timestamp is already available on WorkflowRun, no new API call),
+	// but that is deferred as a follow-up.
 	averages := make(map[string]time.Duration, len(jobDurations))
 	for name, durations := range jobDurations {
 		averages[name] = weightedAverage(durations)

--- a/internal/github/history.go
+++ b/internal/github/history.go
@@ -14,6 +14,13 @@ import (
 
 var runIDRegexp = regexp.MustCompile(`/actions/runs/(\d+)/job/`)
 
+// historyDecayFactor weights recent runs more heavily than older ones in
+// weightedAverage. Each run i (0 = newest) contributes historyDecayFactor^i
+// of the average. 0.7 gives the newest run ~42% of a 10-run average and the
+// oldest ~1%, so a slow run from two weeks ago no longer drags the ETA above
+// where the next run actually lands.
+const historyDecayFactor = 0.7
+
 // ParseRunIDFromURL extracts the workflow run ID from a GitHub Actions details URL.
 func ParseRunIDFromURL(detailsURL string) (int64, error) {
 	matches := runIDRegexp.FindStringSubmatch(detailsURL)
@@ -180,16 +187,38 @@ func averageJobDurations(
 		return nil
 	}
 
+	// durations slices are newest-first: runIDs come from ListWorkflowRunsByID
+	// (which returns runs newest-first when Status="completed"), and each run's
+	// jobs are appended together via ListWorkflowJobs. weightedAverage relies on
+	// this ordering to give the most recent run the largest weight, so any
+	// future refactor that re-shuffles runIDs or durations must preserve it.
 	averages := make(map[string]time.Duration, len(jobDurations))
 	for name, durations := range jobDurations {
-		var total time.Duration
-		for _, d := range durations {
-			total += d
-		}
-		averages[name] = total / time.Duration(len(durations))
+		averages[name] = weightedAverage(durations)
 	}
 
 	return averages
+}
+
+// weightedAverage computes an exponentially decayed weighted average of
+// durations, treating index 0 as the newest (most weight) and later indices as
+// progressively older. With a single duration it returns that duration
+// unchanged; with an empty slice it returns 0. See historyDecayFactor for the
+// decay constant.
+//
+// Ordering invariant: durations MUST be newest-first. averageJobDurations
+// preserves this ordering (see its comment), and the weighting depends on it.
+func weightedAverage(durations []time.Duration) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	var weightedSum, weightSum, weight float64 = 0, 0, 1
+	for _, d := range durations {
+		weightedSum += weight * float64(d)
+		weightSum += weight
+		weight *= historyDecayFactor
+	}
+	return time.Duration(weightedSum / weightSum)
 }
 
 // DiscoverWorkflows resolves run IDs to workflow IDs.

--- a/internal/github/history_test.go
+++ b/internal/github/history_test.go
@@ -14,6 +14,20 @@ func ptrTo(s string) *string {
 	return &s
 }
 
+// weightedBuild2Run is the exponentially decayed weighted average for the
+// "fetches and averages job durations across runs" case: build durations are
+// 2min (newest, run 1) and 4min (oldest, run 2). With decay=0.7 that is
+// (2min*1 + 4min*0.7)/(1+0.7) = 169411764705ns (~2m49.4s), well below the flat
+// mean of 3min.
+const weightedBuild2Run = 169411764705 * time.Nanosecond
+
+// weightedBuild3RunNewShort is the weighted average for the
+// "newer shorter run pulls average below flat mean" case: build durations are
+// 2min (newest), 6min, 6min. With decay=0.7 that is
+// (2min*1 + 6min*0.7 + 6min*0.49)/(1+0.7+0.49) = 250410958904ns (~4m10.4s),
+// below the flat mean of 4m40s but above the newest 2min.
+const weightedBuild3RunNewShort = 250410958904 * time.Nanosecond
+
 func TestParseRunIDFromURL(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -62,6 +76,59 @@ func TestParseRunIDFromURL(t *testing.T) {
 	}
 }
 
+func TestWeightedAverage(t *testing.T) {
+	tests := []struct {
+		name      string
+		durations []time.Duration
+		want      time.Duration
+		wantExact bool
+	}{
+		{name: "empty returns zero", durations: nil, want: 0, wantExact: true},
+		{name: "single returns itself", durations: []time.Duration{5 * time.Minute}, want: 5 * time.Minute, wantExact: true},
+		{name: "two equal collapse to that value", durations: []time.Duration{4 * time.Minute, 4 * time.Minute}, want: 4 * time.Minute, wantExact: true},
+		{
+			name:      "newest dominates two-run average",
+			durations: []time.Duration{2 * time.Minute, 4 * time.Minute},
+			want:      weightedBuild2Run,
+			wantExact: true,
+		},
+		{
+			name:      "newer shorter run below flat mean above newest",
+			durations: []time.Duration{2 * time.Minute, 6 * time.Minute, 6 * time.Minute},
+			want:      weightedBuild3RunNewShort,
+			wantExact: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := weightedAverage(tt.durations)
+			if tt.wantExact {
+				if got != tt.want {
+					t.Errorf("weightedAverage(%v) = %v, want %v", tt.durations, got, tt.want)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("weightedAverage(%v) = %v, want %v", tt.durations, got, tt.want)
+			}
+		})
+	}
+
+	// Sanity bounds for the new-shorter-run case: the weighted average must
+	// sit strictly below the flat mean (4m40s) and strictly above the newest
+	// run (2min), demonstrating that recency weighting pulled the estimate
+	// toward the recent (shorter) runs.
+	flatMean := (2*time.Minute + 6*time.Minute + 6*time.Minute) / 3
+	got := weightedAverage([]time.Duration{2 * time.Minute, 6 * time.Minute, 6 * time.Minute})
+	if got >= flatMean {
+		t.Errorf("weightedAverage should be below flat mean %v, got %v", flatMean, got)
+	}
+	if got <= 2*time.Minute {
+		t.Errorf("weightedAverage should stay above newest run %v, got %v", 2*time.Minute, got)
+	}
+}
+
 func TestAverageJobDurations(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -94,7 +161,7 @@ func TestAverageJobDurations(t *testing.T) {
 				}
 			},
 			wantAverages: map[string]time.Duration{
-				"build": 3 * time.Minute,
+				"build": weightedBuild2Run,
 				"test":  3 * time.Minute,
 			},
 		},
@@ -112,6 +179,33 @@ func TestAverageJobDurations(t *testing.T) {
 			},
 			wantAverages: map[string]time.Duration{
 				"build": time.Minute,
+			},
+		},
+		{
+			name:   "newer shorter run pulls weighted average below flat mean",
+			runIDs: []int64{1, 2, 3},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/owner/repo/actions/runs/1/jobs":
+					// newest run: 2min
+					w.Write([]byte(`{"jobs":[
+						{"name":"build","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:02:00Z"}
+					]}`))
+				case "/repos/owner/repo/actions/runs/2/jobs":
+					// older run: 6min
+					w.Write([]byte(`{"jobs":[
+						{"name":"build","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:06:00Z"}
+					]}`))
+				case "/repos/owner/repo/actions/runs/3/jobs":
+					// oldest run: 6min
+					w.Write([]byte(`{"jobs":[
+						{"name":"build","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:06:00Z"}
+					]}`))
+				}
+			},
+			wantAverages: map[string]time.Duration{
+				"build": weightedBuild3RunNewShort,
 			},
 		},
 		{

--- a/internal/github/history_test.go
+++ b/internal/github/history_test.go
@@ -81,34 +81,25 @@ func TestWeightedAverage(t *testing.T) {
 		name      string
 		durations []time.Duration
 		want      time.Duration
-		wantExact bool
 	}{
-		{name: "empty returns zero", durations: nil, want: 0, wantExact: true},
-		{name: "single returns itself", durations: []time.Duration{5 * time.Minute}, want: 5 * time.Minute, wantExact: true},
-		{name: "two equal collapse to that value", durations: []time.Duration{4 * time.Minute, 4 * time.Minute}, want: 4 * time.Minute, wantExact: true},
+		{name: "empty returns zero", durations: nil, want: 0},
+		{name: "single returns itself", durations: []time.Duration{5 * time.Minute}, want: 5 * time.Minute},
+		{name: "two equal collapse to that value", durations: []time.Duration{4 * time.Minute, 4 * time.Minute}, want: 4 * time.Minute},
 		{
 			name:      "newest dominates two-run average",
 			durations: []time.Duration{2 * time.Minute, 4 * time.Minute},
 			want:      weightedBuild2Run,
-			wantExact: true,
 		},
 		{
 			name:      "newer shorter run below flat mean above newest",
 			durations: []time.Duration{2 * time.Minute, 6 * time.Minute, 6 * time.Minute},
 			want:      weightedBuild3RunNewShort,
-			wantExact: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := weightedAverage(tt.durations)
-			if tt.wantExact {
-				if got != tt.want {
-					t.Errorf("weightedAverage(%v) = %v, want %v", tt.durations, got, tt.want)
-				}
-				return
-			}
 			if got != tt.want {
 				t.Errorf("weightedAverage(%v) = %v, want %v", tt.durations, got, tt.want)
 			}


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- ⏳ [src] historical averages are weighted toward recent runs, fixes #339
- 🩹 [src] address claude_review feedback on #339

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
