### PR TITLE
🛩️ [src] show copilot reviews like they are an action

### DIFF
--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -36,7 +36,10 @@ presumed_averages:
 # Set wait_for_copilot: false for repos that don't use Copilot.
 wait_for_copilot: true
 
-# Maximum time to wait for a Copilot review before timing out and proceeding.
+# Maximum total wall-clock time to wait for a Copilot review before timing out
+# and proceeding. Measured from PR-info time (when the head SHA is known), so
+# it includes the initial_delay window below. copilot_max_wait does NOT add to
+# copilot_initial_delay — it bounds the whole wait.
 copilot_max_wait: 180s
 
 # Polling interval for the Copilot review state query (separate from
@@ -44,5 +47,6 @@ copilot_max_wait: 180s
 copilot_poll_interval: 10s
 
 # Initial delay before the first Copilot review poll, giving GitHub time to
-# create the review request after a push.
+# create the review request after a push. Bounded by copilot_max_wait above
+# (the delay counts toward the total wait, it does not add to it).
 copilot_initial_delay: 15s

--- a/.config.example.yaml
+++ b/.config.example.yaml
@@ -28,3 +28,21 @@ colors:
 # equivalent). Durations use Go time.ParseDuration syntax.
 presumed_averages:
   DCO: 1s
+
+# Copilot code review detection (issue #409). When enabled (default), the TUI
+# gates exit on Copilot review completion in PR mode, mirroring template-repo's
+# wait_for_copilot.sh. Copilot reviews don't appear in StatusCheckRollup, so
+# without this gh-observer would quit "green" while Copilot is still reviewing.
+# Set wait_for_copilot: false for repos that don't use Copilot.
+wait_for_copilot: true
+
+# Maximum time to wait for a Copilot review before timing out and proceeding.
+copilot_max_wait: 180s
+
+# Polling interval for the Copilot review state query (separate from
+# refresh_interval, which governs check-run polling).
+copilot_poll_interval: 10s
+
+# Initial delay before the first Copilot review poll, giving GitHub time to
+# create the review request after a push.
+copilot_initial_delay: 15s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,14 @@ type Config struct {
 	Colors              ColorConfig       `mapstructure:"colors"`
 	EnableLinks         bool              `mapstructure:"enable_links"`
 	PresumedAverages    map[string]string `mapstructure:"presumed_averages"`
+
+	// Copilot code review detection (issue #409). When wait_for_copilot is
+	// true (default), the TUI gates exit on Copilot review completion in PR
+	// mode. The timing parameters mirror template-repo's wait_for_copilot.sh.
+	WaitForCopilot       bool          `mapstructure:"wait_for_copilot"`
+	CopilotMaxWait       time.Duration `mapstructure:"copilot_max_wait"`
+	CopilotPollInterval  time.Duration `mapstructure:"copilot_poll_interval"`
+	CopilotInitialDelay  time.Duration `mapstructure:"copilot_initial_delay"`
 }
 
 func Load() (*Config, error) {
@@ -41,6 +49,10 @@ func Load() (*Config, error) {
 	v.SetDefault("colors.queued", 8)   // Gray
 	v.SetDefault("enable_links", true)
 	v.SetDefault("presumed_averages.DCO", "1s")
+	v.SetDefault("wait_for_copilot", true)
+	v.SetDefault("copilot_max_wait", "180s")
+	v.SetDefault("copilot_poll_interval", "10s")
+	v.SetDefault("copilot_initial_delay", "15s")
 
 	// Config location: ~/.config/gh-observer/config.yaml
 	home, err := os.UserHomeDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -339,3 +339,64 @@ func lookupCI(m map[string]time.Duration, key string) time.Duration {
 	}
 	return 0
 }
+
+func TestLoad_CopilotDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if !cfg.WaitForCopilot {
+		t.Errorf("WaitForCopilot = %v, want true", cfg.WaitForCopilot)
+	}
+	if cfg.CopilotMaxWait != 180*time.Second {
+		t.Errorf("CopilotMaxWait = %v, want 180s", cfg.CopilotMaxWait)
+	}
+	if cfg.CopilotPollInterval != 10*time.Second {
+		t.Errorf("CopilotPollInterval = %v, want 10s", cfg.CopilotPollInterval)
+	}
+	if cfg.CopilotInitialDelay != 15*time.Second {
+		t.Errorf("CopilotInitialDelay = %v, want 15s", cfg.CopilotInitialDelay)
+	}
+}
+
+func TestLoad_CopilotCustom(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "gh-observer")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configContent := `wait_for_copilot: false
+copilot_max_wait: 300s
+copilot_poll_interval: 5s
+copilot_initial_delay: 30s
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if cfg.WaitForCopilot {
+		t.Errorf("WaitForCopilot = %v, want false", cfg.WaitForCopilot)
+	}
+	if cfg.CopilotMaxWait != 300*time.Second {
+		t.Errorf("CopilotMaxWait = %v, want 300s", cfg.CopilotMaxWait)
+	}
+	if cfg.CopilotPollInterval != 5*time.Second {
+		t.Errorf("CopilotPollInterval = %v, want 5s", cfg.CopilotPollInterval)
+	}
+	if cfg.CopilotInitialDelay != 30*time.Second {
+		t.Errorf("CopilotInitialDelay = %v, want 30s", cfg.CopilotInitialDelay)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -3,12 +3,14 @@ package github
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/fini-net/gh-observer/internal/debug"
 	"github.com/google/go-github/v90/github"
+	"github.com/shurcooL/githubv4"
 )
 
 // GetToken retrieves the GitHub token from GITHUB_TOKEN env var or gh CLI
@@ -46,4 +48,16 @@ func NewClient(ctx context.Context) (*github.Client, error) {
 // NewClientFromToken creates a GitHub API client using an already-obtained token.
 func NewClientFromToken(token string) (*github.Client, error) {
 	return github.NewClient(github.WithAuthToken(token))
+}
+
+// safeGraphQLInt converts an architecture-dependent int to githubv4.Int
+// (backed by int32) with a bounds check, preventing silent truncation on
+// platforms where int is 64-bit. Returns an error if the value is out of
+// int32 range. Resolves CodeQL "Incorrect conversion between integer types"
+// finding on githubv4.Int(prNumber) conversions.
+func safeGraphQLInt(n int) (githubv4.Int, error) {
+	if n > math.MaxInt32 || n < math.MinInt32 {
+		return 0, fmt.Errorf("value %d exceeds int32 range for GraphQL Int scalar", n)
+	}
+	return githubv4.Int(n), nil
 }

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -41,16 +41,16 @@ type Annotation struct {
 
 // CheckRunInfo contains enriched check run data with workflow name
 type CheckRunInfo struct {
-	Name         string
-	WorkflowName string
-	AppName      string
-	Summary      string
-	Status       string
-	Conclusion   string
-	StartedAt    *time.Time
-	CompletedAt  *time.Time
-	DetailsURL   string
-	Annotations  []Annotation
+	Name          string
+	WorkflowName  string
+	AppName       string
+	Summary       string
+	Status        string
+	Conclusion    string
+	StartedAt     *time.Time
+	CompletedAt   *time.Time
+	DetailsURL    string
+	Annotations   []Annotation
 	WorkflowRunID int64
 	WorkflowID    int64
 }
@@ -79,19 +79,19 @@ type contextNode struct {
 				} `graphql:"location"`
 			}
 		} `graphql:"annotations(first: 5)"`
-	CheckSuite struct {
-		WorkflowRun struct {
-			DatabaseID BigInt `graphql:"databaseId"`
-			Workflow   struct {
+		CheckSuite struct {
+			WorkflowRun struct {
 				DatabaseID BigInt `graphql:"databaseId"`
-				Name       string
+				Workflow   struct {
+					DatabaseID BigInt `graphql:"databaseId"`
+					Name       string
+				}
+			}
+			App struct {
+				Name string
+				Slug string
 			}
 		}
-		App struct {
-			Name string
-			Slug string
-		}
-	}
 	} `graphql:"... on CheckRun"`
 	StatusContext struct {
 		Context     string
@@ -230,12 +230,17 @@ func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, re
 	var cursor *githubv4.String
 	rateLimitRemaining := 5000
 
+	prNum, err := safeGraphQLInt(prNumber)
+	if err != nil {
+		return nil, rateLimitRemaining, err
+	}
+
 	for {
 		var query pullRequestQuery
 		variables := map[string]any{
 			"owner":    githubv4.String(owner),
 			"repo":     githubv4.String(repo),
-			"prNumber": githubv4.Int(prNumber),
+			"prNumber": prNum,
 		}
 		if cursor != nil {
 			variables["contextsCursor"] = *cursor

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -65,7 +65,7 @@ type copilotReviewQuery struct {
 					}
 					Body string
 				}
-			} `graphql:"reviews(first: 25, orderBy: {field: UPDATED_AT, direction: DESC})"`
+			} `graphql:"reviews(first: 25)"`
 		} `graphql:"pullRequest(number: $prNumber)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
 	RateLimit struct {
@@ -142,7 +142,10 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 	}
 
 	sawStale := false
-	for i := range query.Repository.PullRequest.Reviews.Nodes {
+	// The reviews connection returns nodes in chronological (ascending)
+	// submission order — oldest first, newest last. Iterate in reverse so
+	// the first HEAD-matching node encountered is the most recent review.
+	for i := len(query.Repository.PullRequest.Reviews.Nodes) - 1; i >= 0; i-- {
 		node := &query.Repository.PullRequest.Reviews.Nodes[i]
 		if !strings.EqualFold(node.Author.Login, copilotReviewerLogin) {
 			continue
@@ -154,9 +157,8 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 			continue
 		}
 
-		// Latest review targeting HEAD. Reviews are ordered
-		// UPDATED_AT DESC via the GraphQL orderBy argument, so the first
-		// HEAD-matching node is the most recent one on that commit.
+		// Newest review targeting HEAD (reverse iteration means the
+		// first match is the latest submission on that commit).
 		if headReview == nil {
 			headReview = node
 		}

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -65,7 +65,7 @@ type copilotReviewQuery struct {
 					}
 					Body string
 				}
-			} `graphql:"reviews(first: 25)"`
+			} `graphql:"reviews(last: 25)"`
 		} `graphql:"pullRequest(number: $prNumber)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
 	RateLimit struct {
@@ -143,8 +143,11 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 
 	sawStale := false
 	// The reviews connection returns nodes in chronological (ascending)
-	// submission order — oldest first, newest last. Iterate in reverse so
-	// the first HEAD-matching node encountered is the most recent review.
+	// submission order — oldest first, newest last — whether fetched via
+	// `reviews(first: N)` or `reviews(last: N)`. We query `last: 25` so the
+	// most recent 25 reviews (across all reviewers) are returned; iterate in
+	// reverse so the first HEAD-matching node encountered is the most recent
+	// review on that commit.
 	for i := len(query.Repository.PullRequest.Reviews.Nodes) - 1; i >= 0; i-- {
 		node := &query.Repository.PullRequest.Reviews.Nodes[i]
 		if !strings.EqualFold(node.Author.Login, copilotReviewerLogin) {

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -1,0 +1,192 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/fini-net/gh-observer/internal/debug"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+// copilotReviewerLogin is the GitHub App login for Copilot code reviews.
+const copilotReviewerLogin = "copilot-pull-request-reviewer"
+
+// CopilotReview represents the state of a GitHub Copilot code review on a PR.
+// Unlike CheckRunInfo, reviews have no startedAt/completedAt timestamps, so
+// they must not participate in timing calculations.
+type CopilotReview struct {
+	State        string    // lowercase review state: approved, changes_requested, commented, dismissed, pending
+	SubmittedAt  time.Time // zero if pending or no review found
+	CommitOID    string    // the commit the review targets (empty if no review)
+	Stale        bool      // true if a review exists but targets a different commit than headSHA
+	Pending      bool      // true if Copilot review is requested but not yet submitted
+	NotRequested bool      // true if no Copilot review request and no review found
+}
+
+// CopilotReviewFails returns true if the review state indicates the PR should
+// not merge (changes_requested). This is deliberately separate from
+// FailureConclusion to avoid overloading check-run conclusion semantics.
+func CopilotReviewFails(state string) bool {
+	return state == "changes_requested"
+}
+
+// copilotReviewQuery fetches Copilot review requests and submitted reviews
+// via a second GraphQL path alongside the check-runs query. The
+// reviewRequests fragment uses ... on Bot / ... on User because GitHub
+// silently drops Bot reviewers from the REST requested_reviewers endpoint
+// (issue #288), but GraphQL surfaces them via inline fragments.
+type copilotReviewQuery struct {
+	Repository struct {
+		PullRequest struct {
+			ReviewRequests struct {
+				Nodes []struct {
+					RequestedReviewer struct {
+						Typename string `graphql:"__typename"`
+						Bot      struct {
+							Login string
+						} `graphql:"... on Bot"`
+						User struct {
+							Login string
+						} `graphql:"... on User"`
+					}
+				}
+			} `graphql:"reviewRequests(first: 10)"`
+			Reviews struct {
+				Nodes []struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}
+			} `graphql:"reviews(first: 25)"`
+		} `graphql:"pullRequest(number: $prNumber)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+	RateLimit struct {
+		Remaining int
+	}
+}
+
+// FetchCopilotReview fetches the Copilot code review state for a PR,
+// comparing the review's commit OID against headSHA to detect stale reviews.
+// Returns the review state, the GraphQL rate limit remaining, and any error.
+func FetchCopilotReview(ctx context.Context, token, owner, repo string, prNumber int, headSHA string) (CopilotReview, int, error) {
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(ctx, src)
+	client := githubv4.NewClient(httpClient)
+	return fetchCopilotReview(ctx, client, owner, repo, prNumber, headSHA)
+}
+
+func fetchCopilotReview(ctx context.Context, client graphqlQuerier, owner, repo string, prNumber int, headSHA string) (CopilotReview, int, error) {
+	var query copilotReviewQuery
+	variables := map[string]any{
+		"owner":    githubv4.String(owner),
+		"repo":     githubv4.String(repo),
+		"prNumber": githubv4.Int(prNumber),
+	}
+
+	if err := client.Query(ctx, &query, variables); err != nil {
+		debug.Log("copilot review query failed", "owner", owner, "repo", repo, "pr", prNumber, "err", err)
+		return CopilotReview{}, 5000, err
+	}
+
+	debug.Log("copilot review query success", "owner", owner, "repo", repo, "pr", prNumber,
+		"rate_limit_remaining", query.RateLimit.Remaining,
+		"review_requests", len(query.Repository.PullRequest.ReviewRequests.Nodes),
+		"reviews", len(query.Repository.PullRequest.Reviews.Nodes))
+
+	review := parseCopilotReview(&query, headSHA)
+	return review, query.RateLimit.Remaining, nil
+}
+
+// parseCopilotReview extracts the Copilot review state from a GraphQL response,
+// applying the HEAD-oid completion criterion and stale detection from
+// template-repo's wait_for_copilot.sh.
+func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview {
+	review := CopilotReview{}
+
+	// Check review requests for Copilot
+	copilotRequested := false
+	for _, req := range query.Repository.PullRequest.ReviewRequests.Nodes {
+		login := req.RequestedReviewer.Bot.Login
+		if login == "" {
+			login = req.RequestedReviewer.User.Login
+		}
+		if strings.EqualFold(login, copilotReviewerLogin) {
+			copilotRequested = true
+			break
+		}
+	}
+
+	// Scan reviews for the latest Copilot-authored review targeting HEAD
+	var headReview *struct {
+		Author struct {
+			Login string
+		}
+		State       string
+		SubmittedAt githubv4.DateTime
+		Commit      struct {
+			OID string
+		}
+		Body string
+	}
+
+	sawStale := false
+	for i := range query.Repository.PullRequest.Reviews.Nodes {
+		node := &query.Repository.PullRequest.Reviews.Nodes[i]
+		if !strings.EqualFold(node.Author.Login, copilotReviewerLogin) {
+			continue
+		}
+
+		// Track any Copilot review that doesn't target HEAD as stale
+		if node.Commit.OID != headSHA {
+			sawStale = true
+			continue
+		}
+
+		// Latest review targeting HEAD (reviews are first:25, newest first)
+		if headReview == nil {
+			headReview = node
+		}
+	}
+
+	switch {
+	case headReview != nil:
+		review.State = strings.ToLower(headReview.State)
+		review.CommitOID = headReview.Commit.OID
+		if !headReview.SubmittedAt.IsZero() {
+			review.SubmittedAt = headReview.SubmittedAt.Time
+		}
+		// Complete (state is APPROVED/CHANGES_REQUESTED/COMMENTED/DISMISSED),
+		// not PENDING — a PENDING review on HEAD means it's still in progress.
+		if review.State == "pending" {
+			review.Pending = true
+		}
+	case copilotRequested:
+		// Review requested but no submitted review on HEAD yet
+		review.Pending = true
+		review.State = "pending"
+	case sawStale:
+		// No HEAD review, but a stale one exists — mark stale so the caller
+		// can warn the user to re-request.
+		review.Stale = true
+		review.NotRequested = true
+	default:
+		review.NotRequested = true
+	}
+
+	// If we found a HEAD review but also saw stale ones, the stale flag
+	// still matters for the warning. But if HEAD review is complete,
+	// staleness is informational only — set it but don't block.
+	if sawStale && headReview == nil {
+		review.Stale = true
+	}
+
+	return review
+}

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -85,10 +85,14 @@ func FetchCopilotReview(ctx context.Context, token, owner, repo string, prNumber
 
 func fetchCopilotReview(ctx context.Context, client graphqlQuerier, owner, repo string, prNumber int, headSHA string) (CopilotReview, int, error) {
 	var query copilotReviewQuery
+	prNum, err := safeGraphQLInt(prNumber)
+	if err != nil {
+		return CopilotReview{}, 5000, err
+	}
 	variables := map[string]any{
 		"owner":    githubv4.String(owner),
 		"repo":     githubv4.String(repo),
-		"prNumber": githubv4.Int(prNumber),
+		"prNumber": prNum,
 	}
 
 	if err := client.Query(ctx, &query, variables); err != nil {

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/fini-net/gh-observer/internal/debug"
 	"github.com/shurcooL/githubv4"
@@ -17,12 +16,11 @@ const copilotReviewerLogin = "copilot-pull-request-reviewer"
 // Unlike CheckRunInfo, reviews have no startedAt/completedAt timestamps, so
 // they must not participate in timing calculations.
 type CopilotReview struct {
-	State        string    // lowercase review state: approved, changes_requested, commented, dismissed, pending
-	SubmittedAt  time.Time // zero if pending or no review found
-	CommitOID    string    // the commit the review targets (empty if no review)
-	Stale        bool      // true if a review exists but targets a different commit than headSHA
-	Pending      bool      // true if Copilot review is requested but not yet submitted
-	NotRequested bool      // true if no Copilot review request and no review found
+	State        string // lowercase review state: approved, changes_requested, commented, dismissed, pending
+	CommitOID    string // the commit the review targets (empty if no review)
+	Stale        bool   // true if a review exists but targets a different commit than headSHA
+	Pending      bool   // true if Copilot review is requested but not yet submitted
+	NotRequested bool   // true if no Copilot review request and no review found
 }
 
 // CopilotReviewFails returns true if the review state indicates the PR should
@@ -171,9 +169,6 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 	case headReview != nil:
 		review.State = strings.ToLower(headReview.State)
 		review.CommitOID = headReview.Commit.OID
-		if !headReview.SubmittedAt.IsZero() {
-			review.SubmittedAt = headReview.SubmittedAt.Time
-		}
 		// Complete (state is APPROVED/CHANGES_REQUESTED/COMMENTED/DISMISSED),
 		// not PENDING — a PENDING review on HEAD means it's still in progress.
 		if review.State == "pending" {

--- a/internal/github/reviews.go
+++ b/internal/github/reviews.go
@@ -65,7 +65,7 @@ type copilotReviewQuery struct {
 					}
 					Body string
 				}
-			} `graphql:"reviews(first: 25)"`
+			} `graphql:"reviews(first: 25, orderBy: {field: UPDATED_AT, direction: DESC})"`
 		} `graphql:"pullRequest(number: $prNumber)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
 	RateLimit struct {
@@ -150,7 +150,9 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 			continue
 		}
 
-		// Latest review targeting HEAD (reviews are first:25, newest first)
+		// Latest review targeting HEAD. Reviews are ordered
+		// UPDATED_AT DESC via the GraphQL orderBy argument, so the first
+		// HEAD-matching node is the most recent one on that commit.
 		if headReview == nil {
 			headReview = node
 		}
@@ -169,23 +171,19 @@ func parseCopilotReview(query *copilotReviewQuery, headSHA string) CopilotReview
 			review.Pending = true
 		}
 	case copilotRequested:
-		// Review requested but no submitted review on HEAD yet
+		// Review requested but no submitted review on HEAD yet. A fresh
+		// review is actively pending, so do NOT set Stale even if older
+		// reviews from previous commits are present — the pending review
+		// takes precedence over the stale record.
 		review.Pending = true
 		review.State = "pending"
 	case sawStale:
-		// No HEAD review, but a stale one exists — mark stale so the caller
-		// can warn the user to re-request.
+		// No HEAD review and no pending request, but a stale one exists —
+		// mark stale so the caller can warn the user to re-request.
 		review.Stale = true
 		review.NotRequested = true
 	default:
 		review.NotRequested = true
-	}
-
-	// If we found a HEAD review but also saw stale ones, the stale flag
-	// still matters for the warning. But if HEAD review is complete,
-	// staleness is informational only — set it but don't block.
-	if sawStale && headReview == nil {
-		review.Stale = true
 	}
 
 	return review

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -392,6 +392,34 @@ func TestFetchCopilotReview(t *testing.T) {
 			wantRateLimit: 4991,
 		},
 		{
+			// Regression: the reviews connection returns nodes in
+			// ascending submission order (oldest first). When multiple
+			// Copilot reviews target HEAD, the last (newest) one must win.
+			// Here an older CHANGES_REQUESTED precedes a newer APPROVED;
+			// the result must be "approved", not "changes_requested".
+			name: "multiple HEAD reviews - newest wins (ascending order)",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "CHANGES_REQUESTED", headSHA, "2025-01-01T00:00:00Z"),
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", headSHA, "2025-01-02T00:00:00Z"),
+				},
+				4989,
+			),
+			wantState:     "approved",
+			wantRateLimit: 4989,
+		},
+		{
 			name:          "query error",
 			err:           fmt.Errorf("graphql error"),
 			wantErr:       true,

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -231,6 +231,47 @@ func TestFetchCopilotReview(t *testing.T) {
 			wantRateLimit:    4996,
 		},
 		{
+			// Bug #3 from review: a fresh review request (copilotRequested)
+			// combined with a stale review from a previous commit and no
+			// HEAD review yet must report Pending=true and Stale=false.
+			// Previously the trailing sawStale block also set Stale=true,
+			// masking the in-progress review and satisfying the gate.
+			name: "requested with stale review present - pending wins, not stale",
+			query: makeReviewQuery(
+				[]struct {
+					RequestedReviewer struct {
+						Typename string `graphql:"__typename"`
+						Bot      struct {
+							Login string
+						} `graphql:"... on Bot"`
+						User struct {
+							Login string
+						} `graphql:"... on User"`
+					}
+				}{
+					makeRequestNode("copilot-pull-request-reviewer"),
+				},
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", "oldsha789", ""),
+				},
+				4990,
+			),
+			wantPending:   true,
+			wantState:     "pending",
+			wantStale:     false,
+			wantRateLimit: 4990,
+		},
+		{
 			name: "in progress - requested but no review",
 			query: makeReviewQuery(
 				[]struct {

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -43,6 +44,12 @@ func makeReviewNode(authorLogin, state, commitOID, submittedAt string) struct {
 	}
 	Body string
 } {
+	var submittedAtTime time.Time
+	if submittedAt != "" {
+		if t, err := time.Parse(time.RFC3339, submittedAt); err == nil {
+			submittedAtTime = t
+		}
+	}
 	return struct {
 		Author struct {
 			Login string
@@ -56,7 +63,7 @@ func makeReviewNode(authorLogin, state, commitOID, submittedAt string) struct {
 	}{
 		Author:      struct{ Login string }{Login: authorLogin},
 		State:       state,
-		SubmittedAt: githubv4.DateTime{},
+		SubmittedAt: githubv4.DateTime{Time: submittedAtTime},
 		Commit:      struct{ OID string }{OID: commitOID},
 	}
 }

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -469,6 +469,55 @@ func TestFetchCopilotReview(t *testing.T) {
 	}
 }
 
+// TestFetchCopilotReview_BeyondFirstPage is a regression test for the
+// `reviews(first: 25)` bug (issue #409 review). On a heavily-reviewed PR with
+// more than 25 total reviews across all reviewers, `first: 25` returned the
+// oldest 25 of the ascending reviews connection, dropping the newest Copilot
+// review on HEAD entirely — so headReview stayed nil and the gate fell
+// through to "not requested", silently passing a changes_requested review.
+// With `reviews(last: 25)` the most recent 25 are returned and the newest
+// Copilot review on HEAD is found. Here 25 non-Copilot reviews precede a
+// Copilot CHANGES_REQUESTED on HEAD; the fetch must surface that state.
+func TestFetchCopilotReview_BeyondFirstPage(t *testing.T) {
+	headSHA := "abc123def456"
+
+	var reviews []struct {
+		Author struct {
+			Login string
+		}
+		State       string
+		SubmittedAt githubv4.DateTime
+		Commit      struct {
+			OID string
+		}
+		Body string
+	}
+	// 25 non-Copilot reviews fill the first page under the old `first: 25`
+	// semantics, pushing the Copilot review out of the returned window.
+	for i := 0; i < 25; i++ {
+		reviews = append(reviews, makeReviewNode("some-user", "COMMENTED", headSHA, ""))
+	}
+	// Newest Copilot review on HEAD — the one that must win.
+	reviews = append(reviews, makeReviewNode("copilot-pull-request-reviewer", "CHANGES_REQUESTED", headSHA, "2025-01-02T00:00:00Z"))
+
+	query := makeReviewQuery(nil, reviews, 4980)
+	mock := &mockReviewQuerier{responses: []mockReviewResponse{{query: query}}}
+
+	review, rateLimit, err := fetchCopilotReview(context.Background(), mock, "owner", "repo", 42, headSHA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if review.State != "changes_requested" {
+		t.Errorf("State = %q, want %q (newest Copilot review on HEAD must be found, not dropped)", review.State, "changes_requested")
+	}
+	if review.NotRequested {
+		t.Error("NotRequested = true, want false (must not fall through to not-requested when a HEAD review exists beyond the old first:25 window)")
+	}
+	if rateLimit != 4980 {
+		t.Errorf("rateLimit = %d, want 4980", rateLimit)
+	}
+}
+
 func TestCopilotReviewFails(t *testing.T) {
 	tests := []struct {
 		state string

--- a/internal/github/reviews_test.go
+++ b/internal/github/reviews_test.go
@@ -1,0 +1,413 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type mockReviewResponse struct {
+	query *copilotReviewQuery
+	err   error
+}
+
+type mockReviewQuerier struct {
+	responses []mockReviewResponse
+	callCount int
+}
+
+func (m *mockReviewQuerier) Query(_ context.Context, q interface{}, _ map[string]interface{}) error {
+	if m.callCount >= len(m.responses) {
+		return fmt.Errorf("unexpected query call #%d", m.callCount+1)
+	}
+	resp := m.responses[m.callCount]
+	m.callCount++
+	if resp.err != nil {
+		return resp.err
+	}
+	target := q.(*copilotReviewQuery)
+	*target = *resp.query
+	return nil
+}
+
+func makeReviewNode(authorLogin, state, commitOID, submittedAt string) struct {
+	Author struct {
+		Login string
+	}
+	State       string
+	SubmittedAt githubv4.DateTime
+	Commit      struct {
+		OID string
+	}
+	Body string
+} {
+	return struct {
+		Author struct {
+			Login string
+		}
+		State       string
+		SubmittedAt githubv4.DateTime
+		Commit      struct {
+			OID string
+		}
+		Body string
+	}{
+		Author:      struct{ Login string }{Login: authorLogin},
+		State:       state,
+		SubmittedAt: githubv4.DateTime{},
+		Commit:      struct{ OID string }{OID: commitOID},
+	}
+}
+
+func makeRequestNode(login string) struct {
+	RequestedReviewer struct {
+		Typename string `graphql:"__typename"`
+		Bot      struct {
+			Login string
+		} `graphql:"... on Bot"`
+		User struct {
+			Login string
+		} `graphql:"... on User"`
+	}
+} {
+	return struct {
+		RequestedReviewer struct {
+			Typename string `graphql:"__typename"`
+			Bot      struct {
+				Login string
+			} `graphql:"... on Bot"`
+			User struct {
+				Login string
+			} `graphql:"... on User"`
+		}
+	}{
+		RequestedReviewer: struct {
+			Typename string `graphql:"__typename"`
+			Bot      struct {
+				Login string
+			} `graphql:"... on Bot"`
+			User struct {
+				Login string
+			} `graphql:"... on User"`
+		}{
+			Typename: "Bot",
+			Bot:      struct{ Login string }{Login: login},
+		},
+	}
+}
+
+func makeReviewQuery(requests []struct {
+	RequestedReviewer struct {
+		Typename string `graphql:"__typename"`
+		Bot      struct {
+			Login string
+		} `graphql:"... on Bot"`
+		User struct {
+			Login string
+		} `graphql:"... on User"`
+	}
+}, reviews []struct {
+	Author struct {
+		Login string
+	}
+	State       string
+	SubmittedAt githubv4.DateTime
+	Commit      struct {
+		OID string
+	}
+	Body string
+}, rateLimit int) *copilotReviewQuery {
+	q := &copilotReviewQuery{
+		RateLimit: struct{ Remaining int }{Remaining: rateLimit},
+	}
+	q.Repository.PullRequest.ReviewRequests.Nodes = requests
+	q.Repository.PullRequest.Reviews.Nodes = reviews
+	return q
+}
+
+func TestFetchCopilotReview(t *testing.T) {
+	headSHA := "abc123def456"
+
+	tests := []struct {
+		name             string
+		query            *copilotReviewQuery
+		err              error
+		wantState        string
+		wantStale        bool
+		wantPending      bool
+		wantNotRequested bool
+		wantRateLimit    int
+		wantErr          bool
+	}{
+		{
+			name: "approved on HEAD",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", headSHA, ""),
+				},
+				4999,
+			),
+			wantState:     "approved",
+			wantRateLimit: 4999,
+		},
+		{
+			name: "changes_requested on HEAD",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "CHANGES_REQUESTED", headSHA, ""),
+				},
+				4998,
+			),
+			wantState:     "changes_requested",
+			wantRateLimit: 4998,
+		},
+		{
+			name: "commented on HEAD",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "COMMENTED", headSHA, ""),
+				},
+				4997,
+			),
+			wantState:     "commented",
+			wantRateLimit: 4997,
+		},
+		{
+			name: "stale review targets old commit",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", "oldsha789", ""),
+				},
+				4996,
+			),
+			wantStale:        true,
+			wantNotRequested: true,
+			wantRateLimit:    4996,
+		},
+		{
+			name: "in progress - requested but no review",
+			query: makeReviewQuery(
+				[]struct {
+					RequestedReviewer struct {
+						Typename string `graphql:"__typename"`
+						Bot      struct {
+							Login string
+						} `graphql:"... on Bot"`
+						User struct {
+							Login string
+						} `graphql:"... on User"`
+					}
+				}{
+					makeRequestNode("copilot-pull-request-reviewer"),
+				},
+				nil,
+				4995,
+			),
+			wantPending:   true,
+			wantState:     "pending",
+			wantRateLimit: 4995,
+		},
+		{
+			name: "pending review on HEAD (submitted but state PENDING)",
+			query: makeReviewQuery(
+				[]struct {
+					RequestedReviewer struct {
+						Typename string `graphql:"__typename"`
+						Bot      struct {
+							Login string
+						} `graphql:"... on Bot"`
+						User struct {
+							Login string
+						} `graphql:"... on User"`
+					}
+				}{
+					makeRequestNode("copilot-pull-request-reviewer"),
+				},
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "PENDING", headSHA, ""),
+				},
+				4994,
+			),
+			wantPending:   true,
+			wantState:     "pending",
+			wantRateLimit: 4994,
+		},
+		{
+			name: "not requested - no requests and no reviews",
+			query: makeReviewQuery(
+				nil,
+				nil,
+				4993,
+			),
+			wantNotRequested: true,
+			wantRateLimit:    4993,
+		},
+		{
+			name: "non-copilot review ignored",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("some-user", "APPROVED", headSHA, ""),
+				},
+				4992,
+			),
+			wantNotRequested: true,
+			wantRateLimit:    4992,
+		},
+		{
+			name: "stale review plus fresh HEAD review - not stale (fresh wins)",
+			query: makeReviewQuery(
+				nil,
+				[]struct {
+					Author struct {
+						Login string
+					}
+					State       string
+					SubmittedAt githubv4.DateTime
+					Commit      struct {
+						OID string
+					}
+					Body string
+				}{
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", headSHA, ""),
+					makeReviewNode("copilot-pull-request-reviewer", "APPROVED", "oldsha789", ""),
+				},
+				4991,
+			),
+			wantState:     "approved",
+			wantRateLimit: 4991,
+		},
+		{
+			name:          "query error",
+			err:           fmt.Errorf("graphql error"),
+			wantErr:       true,
+			wantRateLimit: 5000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockReviewQuerier{
+				responses: []mockReviewResponse{{query: tt.query, err: tt.err}},
+			}
+
+			review, rateLimit, err := fetchCopilotReview(context.Background(), mock, "owner", "repo", 42, headSHA)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if rateLimit != tt.wantRateLimit {
+					t.Errorf("rate limit = %d, want %d", rateLimit, tt.wantRateLimit)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if review.State != tt.wantState {
+				t.Errorf("State = %q, want %q", review.State, tt.wantState)
+			}
+			if review.Stale != tt.wantStale {
+				t.Errorf("Stale = %v, want %v", review.Stale, tt.wantStale)
+			}
+			if review.Pending != tt.wantPending {
+				t.Errorf("Pending = %v, want %v", review.Pending, tt.wantPending)
+			}
+			if review.NotRequested != tt.wantNotRequested {
+				t.Errorf("NotRequested = %v, want %v", review.NotRequested, tt.wantNotRequested)
+			}
+			if rateLimit != tt.wantRateLimit {
+				t.Errorf("rateLimit = %d, want %d", rateLimit, tt.wantRateLimit)
+			}
+			if mock.callCount != 1 {
+				t.Errorf("callCount = %d, want 1", mock.callCount)
+			}
+		})
+	}
+}
+
+func TestCopilotReviewFails(t *testing.T) {
+	tests := []struct {
+		state string
+		want  bool
+	}{
+		{"changes_requested", true},
+		{"approved", false},
+		{"commented", false},
+		{"dismissed", false},
+		{"pending", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := CopilotReviewFails(tt.state); got != tt.want {
+			t.Errorf("CopilotReviewFails(%q) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -85,6 +85,26 @@ func GetCheckIcon(status, conclusion string) string {
 	}
 }
 
+// GetCopilotReviewIcon returns the icon for a Copilot review row, keyed on
+// review state (not check status/conclusion). Reviews are a distinct concept
+// from check runs, so this is separate from GetCheckIcon (issue #409).
+func GetCopilotReviewIcon(state string) string {
+	switch state {
+	case "approved":
+		return "✓"
+	case "changes_requested":
+		return "✗"
+	case "commented":
+		return "💬"
+	case "dismissed":
+		return "⊘"
+	case "pending":
+		return "◐"
+	default:
+		return "?"
+	}
+}
+
 // FormatCheckName formats the check name as "Workflow / Job", "App / Job", or just "Job"
 func FormatCheckName(check ghclient.CheckRunInfo) string {
 	if check.WorkflowName != "" {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -50,13 +50,12 @@ type JobAveragesPartialMsg struct {
 // StatusCheckRollup.Contexts), so they require a separate fetch path and
 // their own message type (issue #409).
 type CopilotReviewMsg struct {
-	State               string
-	SubmittedAt         time.Time
-	CommitOID           string
-	Stale               bool
-	Pending             bool
-	NotRequested        bool
-	NotRequestedStreak  int
-	RateLimitRemaining  int
-	Err                 error
+	State              string
+	SubmittedAt        time.Time
+	CommitOID          string
+	Stale              bool
+	Pending            bool
+	NotRequested       bool
+	RateLimitRemaining int
+	Err                error
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -44,3 +44,19 @@ type JobAveragesPartialMsg struct {
 	Averages   map[string]time.Duration
 	Err        error
 }
+
+// CopilotReviewMsg carries the Copilot code review state for the PR's HEAD
+// commit. Copilot reviews live in PullRequest.reviews (not
+// StatusCheckRollup.Contexts), so they require a separate fetch path and
+// their own message type (issue #409).
+type CopilotReviewMsg struct {
+	State               string
+	SubmittedAt         time.Time
+	CommitOID           string
+	Stale               bool
+	Pending             bool
+	NotRequested        bool
+	NotRequestedStreak  int
+	RateLimitRemaining  int
+	Err                 error
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -51,8 +51,6 @@ type JobAveragesPartialMsg struct {
 // their own message type (issue #409).
 type CopilotReviewMsg struct {
 	State              string
-	SubmittedAt        time.Time
-	CommitOID          string
 	Stale              bool
 	Pending            bool
 	NotRequested       bool

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -86,10 +86,28 @@ type Model struct {
 	// (e.g. "1s") instead of blank. Configured via config.yaml's
 	// presumed_averages map.
 	presumedAverages map[string]time.Duration
+
+	// Copilot code review detection (issue #409). PR mode only — run mode
+	// has no reviews object to query. copilotPending gates exit; copilotStale
+	// surfaces a warning. copilotWaitStartTime is set to now + initial delay
+	// on PRInfoMsg, and copilotMaxWait bounds how long we wait before
+	// timing out and proceeding.
+	waitForCopilot        bool
+	copilotMaxWait        time.Duration
+	copilotPollInterval   time.Duration
+	copilotInitialDelay   time.Duration
+	copilotState          string
+	copilotStale          bool
+	copilotSubmittedAt    time.Time
+	copilotPending        bool
+	copilotWaitStartTime  time.Time
+	copilotLastPoll       time.Time
+	copilotNotReqStreak   int
+	copilotReviewComplete bool
 }
 
 // NewModel creates a new TUI model
-func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool, presumedAverages map[string]time.Duration) Model {
+func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refreshInterval time.Duration, styles Styles, enableLinks bool, noAvg bool, presumedAverages map[string]time.Duration, waitForCopilot bool, copilotMaxWait, copilotPollInterval, copilotInitialDelay time.Duration) Model {
 	s := spinner.New(spinner.WithSpinner(spinner.Dot))
 
 	return Model{
@@ -114,6 +132,10 @@ func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refr
 		dispatchedWorkflowFetch: make(map[int64]bool),
 		seenCheckKeys:          make(map[string]bool),
 		presumedAverages:        presumedAverages,
+		waitForCopilot:          waitForCopilot,
+		copilotMaxWait:          copilotMaxWait,
+		copilotPollInterval:     copilotPollInterval,
+		copilotInitialDelay:     copilotInitialDelay,
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -89,21 +89,23 @@ type Model struct {
 
 	// Copilot code review detection (issue #409). PR mode only — run mode
 	// has no reviews object to query. copilotPending gates exit; copilotStale
-	// surfaces a warning. copilotWaitStartTime is set to now + initial delay
-	// on PRInfoMsg, and copilotMaxWait bounds how long we wait before
-	// timing out and proceeding.
-	waitForCopilot        bool
-	copilotMaxWait        time.Duration
-	copilotPollInterval   time.Duration
-	copilotInitialDelay   time.Duration
-	copilotState          string
-	copilotStale          bool
-	copilotSubmittedAt    time.Time
-	copilotPending        bool
-	copilotWaitStartTime  time.Time
-	copilotLastPoll       time.Time
-	copilotNotReqStreak   int
-	copilotReviewComplete bool
+	// surfaces a warning. copilotWaitStartTime is set to PRInfoMsg time and
+	// copilotMaxWait bounds the total wall-clock wait before timing out and
+	// proceeding. copilotPollStartTime is set to now + initialDelay and gates
+	// when the first Copilot review poll may fire (gives GitHub time to create
+	// the review request after a push).
+	waitForCopilot         bool
+	copilotMaxWait         time.Duration
+	copilotPollInterval    time.Duration
+	copilotInitialDelay    time.Duration
+	copilotState           string
+	copilotStale           bool
+	copilotPending         bool
+	copilotWaitStartTime   time.Time
+	copilotPollStartTime   time.Time
+	copilotLastPoll        time.Time
+	copilotNotReqStreak    int
+	copilotReviewComplete  bool
 }
 
 // NewModel creates a new TUI model

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -138,6 +138,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the first fetch once the initial-delay window elapses. This also lets
 		// the two-consecutive-not-requested streak logic run from a real cold
 		// start (copilotPending must be true for TickMsg to re-poll).
+		//
+		// NOTE: shaChanged is currently unreachable in production — fetchPRInfo
+		// is only dispatched once from Init(), so PRInfoMsg fires once per run.
+		// The reset is kept for forward compatibility if PR info is ever
+		// re-polled (e.g. to detect force-pushes mid-watch).
 		if m.waitForCopilot {
 			if shaChanged {
 				m.copilotState = ""

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -130,18 +130,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Start Copilot review polling once headSHA is known (issue #409).
 		// If the head SHA changed (new push), reset copilot state so a stale
 		// review from the old commit doesn't gate or falsely complete.
+		//
+		// The first poll is NOT dispatched here: copilotInitialDelay exists to
+		// give GitHub time to create the review request after a push, so we
+		// optimistically mark the gate as pending and let the TickMsg path fire
+		// the first fetch once the initial-delay window elapses. This also lets
+		// the two-consecutive-not-requested streak logic run from a real cold
+		// start (copilotPending must be true for TickMsg to re-poll).
 		if m.waitForCopilot {
 			if shaChanged {
 				m.copilotState = ""
 				m.copilotStale = false
 				m.copilotSubmittedAt = time.Time{}
-				m.copilotPending = false
 				m.copilotReviewComplete = false
 				m.copilotNotReqStreak = 0
 				debug.Log("copilot state reset on head SHA change", "old", m.headSHA, "new", msg.HeadSHA)
 			}
+			m.copilotPending = true
+			m.copilotReviewComplete = false
 			m.copilotWaitStartTime = time.Now().Add(m.copilotInitialDelay)
-			cmds = append(cmds, fetchCopilotReview(m.ctx, m.token, m.owner, m.repo, m.prNumber, m.headSHA))
+			debug.Log("copilot gate armed, first poll after initial delay",
+				"delay", m.copilotInitialDelay, "wait_start", m.copilotWaitStartTime)
 		}
 
 		return m, tea.Batch(cmds...)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -94,11 +94,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tick(m.refreshInterval * 3)
 		}
 
-		// Only poll if we have the PR number
-		return m, tea.Batch(
+		cmds := []tea.Cmd{
 			fetchCheckRuns(m.ctx, m.token, m.owner, m.repo, m.prNumber),
 			tick(m.refreshInterval),
-		)
+		}
+
+		// Poll Copilot review on its own cadence, gated on rate limit and
+		// the initial delay window (issue #409).
+		if m.waitForCopilot && m.copilotPending && !m.quitting &&
+			m.rateLimitRemaining >= minRateLimitForFetch &&
+			!m.copilotWaitStartTime.IsZero() && time.Now().After(m.copilotWaitStartTime) &&
+			(m.copilotLastPoll.IsZero() || time.Since(m.copilotLastPoll) >= m.copilotPollInterval) {
+			cmds = append(cmds, fetchCopilotReview(m.ctx, m.token, m.owner, m.repo, m.prNumber, m.headSHA))
+		}
+
+		return m, tea.Batch(cmds...)
 
 	case PRInfoMsg:
 		if msg.Err != nil {
@@ -106,16 +116,41 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		shaChanged := m.headSHA != "" && m.headSHA != msg.HeadSHA
+
 		m.prTitle = msg.Title
 		m.headSHA = msg.HeadSHA
 		m.prCreatedAt = msg.CreatedAt
 		m.headCommitTime = msg.HeadCommitTime
 
-		// Start polling checks now that we have the PR info
-		return m, fetchCheckRuns(m.ctx, m.token, m.owner, m.repo, m.prNumber)
+		cmds := []tea.Cmd{
+			fetchCheckRuns(m.ctx, m.token, m.owner, m.repo, m.prNumber),
+		}
+
+		// Start Copilot review polling once headSHA is known (issue #409).
+		// If the head SHA changed (new push), reset copilot state so a stale
+		// review from the old commit doesn't gate or falsely complete.
+		if m.waitForCopilot {
+			if shaChanged {
+				m.copilotState = ""
+				m.copilotStale = false
+				m.copilotSubmittedAt = time.Time{}
+				m.copilotPending = false
+				m.copilotReviewComplete = false
+				m.copilotNotReqStreak = 0
+				debug.Log("copilot state reset on head SHA change", "old", m.headSHA, "new", msg.HeadSHA)
+			}
+			m.copilotWaitStartTime = time.Now().Add(m.copilotInitialDelay)
+			cmds = append(cmds, fetchCopilotReview(m.ctx, m.token, m.owner, m.repo, m.prNumber, m.headSHA))
+		}
+
+		return m, tea.Batch(cmds...)
 
 	case ChecksUpdateMsg:
 		return m.handleChecksUpdate(msg)
+
+	case CopilotReviewMsg:
+		return m.handleCopilotReview(msg)
 
 	case WorkflowsDiscoveredMsg:
 		if msg.Err != nil {
@@ -356,8 +391,8 @@ func (m *Model) handleChecksUpdate(msg ChecksUpdateMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if allChecksComplete(m.checkRuns) && canTrustCompletion(m) {
-		m.exitCode = determineExitCode(m.checkRuns)
+	if allChecksComplete(m.checkRuns) && canTrustCompletion(m) && copilotGateSatisfied(m) {
+		m.exitCode = determineExitCode(m.checkRuns, m.copilotState, m.waitForCopilot)
 		m.checksComplete = true
 		if !m.avgFetchPending && len(m.pendingWorkflowFetch) == 0 {
 			m.quitting = true
@@ -367,6 +402,87 @@ func (m *Model) handleChecksUpdate(msg ChecksUpdateMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// copilotGateSatisfied returns true when the Copilot review is not blocking
+// exit — either because the feature is disabled, the review is complete, the
+// review is stale (self-limiting; next poll re-evaluates), or the max wait
+// has elapsed (issue #409).
+func copilotGateSatisfied(m *Model) bool {
+	if !m.waitForCopilot {
+		return true
+	}
+	if !m.copilotPending {
+		return true
+	}
+	// A stale review doesn't block — it's informational and self-corrects.
+	if m.copilotStale {
+		return true
+	}
+	// Max wait elapsed — stop waiting and proceed.
+	if !m.copilotWaitStartTime.IsZero() && time.Since(m.copilotWaitStartTime) >= m.copilotMaxWait {
+		debug.Log("copilot max wait elapsed, proceeding", "max_wait", m.copilotMaxWait)
+		return true
+	}
+	return false
+}
+
+// handleCopilotReview processes Copilot review state updates (issue #409).
+func (m *Model) handleCopilotReview(msg CopilotReviewMsg) (tea.Model, tea.Cmd) {
+	m.copilotLastPoll = time.Now()
+
+	if msg.Err != nil {
+		debug.Log("copilot review fetch error", "err", msg.Err)
+		m.err = msg.Err
+		return m, nil
+	}
+
+	if msg.RateLimitRemaining > 0 && msg.RateLimitRemaining < m.rateLimitRemaining {
+		m.rateLimitRemaining = msg.RateLimitRemaining
+	}
+
+	// Two-consecutive-not-found rule: require two consecutive "not requested
+	// and no HEAD review" polls before declaring Copilot not requested. This
+	// absorbs GraphQL read lag after a REST POST that requested the review.
+	if msg.NotRequested && !msg.Stale {
+		m.copilotNotReqStreak++
+		if m.copilotNotReqStreak < 2 {
+			debug.Log("copilot not requested (streak incomplete)", "streak", m.copilotNotReqStreak)
+			return m, nil
+		}
+		// Two consecutive not-requested: Copilot isn't on this PR.
+		m.copilotPending = false
+		m.copilotReviewComplete = true
+		m.copilotState = ""
+		debug.Log("copilot not requested (confirmed)")
+		return m, nil
+	}
+	m.copilotNotReqStreak = 0
+
+	m.copilotState = msg.State
+	m.copilotStale = msg.Stale
+	m.copilotSubmittedAt = msg.SubmittedAt
+
+	if msg.Pending {
+		m.copilotPending = true
+		m.copilotReviewComplete = false
+		debug.Log("copilot review in progress")
+		return m, nil
+	}
+
+	// Review complete (or stale with no pending) — stop blocking.
+	m.copilotPending = false
+	m.copilotReviewComplete = true
+	debug.Log("copilot review complete", "state", msg.State, "stale", msg.Stale)
+
+	// If checks are already done and averages fetched, quit now.
+	if m.checksComplete && !m.avgFetchPending && len(m.pendingWorkflowFetch) == 0 {
+		m.exitCode = determineExitCode(m.checkRuns, m.copilotState, m.waitForCopilot)
+		m.quitting = true
+		return m, tea.Quit
+	}
+
+	return m, nil
 }
 
 // tick creates a command that sends a TickMsg after duration d
@@ -460,6 +576,27 @@ func fetchCheckRuns(ctx context.Context, token, owner, repo string, prNumber int
 	}
 }
 
+// fetchCopilotReview fetches the Copilot code review state via GraphQL
+// (issue #409). This is a second query path alongside fetchCheckRuns, hitting
+// PullRequest.reviews instead of StatusCheckRollup.Contexts.
+func fetchCopilotReview(ctx context.Context, token, owner, repo string, prNumber int, headSHA string) tea.Cmd {
+	return func() tea.Msg {
+		review, rateLimit, err := ghclient.FetchCopilotReview(ctx, token, owner, repo, prNumber, headSHA)
+		if err != nil {
+			return CopilotReviewMsg{Err: err, RateLimitRemaining: rateLimit}
+		}
+		return CopilotReviewMsg{
+			State:              review.State,
+			SubmittedAt:        review.SubmittedAt,
+			CommitOID:          review.CommitOID,
+			Stale:              review.Stale,
+			Pending:            review.Pending,
+			NotRequested:       review.NotRequested,
+			RateLimitRemaining: rateLimit,
+		}
+	}
+}
+
 // allChecksComplete returns true if all checks have finished
 func allChecksComplete(checks []ghclient.CheckRunInfo) bool {
 	if len(checks) == 0 {
@@ -475,12 +612,17 @@ func allChecksComplete(checks []ghclient.CheckRunInfo) bool {
 	return true
 }
 
-// determineExitCode returns 1 if any check failed, 0 otherwise
-func determineExitCode(checks []ghclient.CheckRunInfo) int {
+// determineExitCode returns 1 if any check failed or the Copilot review
+// requested changes, 0 otherwise. The copilotState and waitForCopilot params
+// are only meaningful in PR mode (issue #409); run mode passes "" and false.
+func determineExitCode(checks []ghclient.CheckRunInfo, copilotState string, waitForCopilot bool) int {
 	for _, check := range checks {
 		if ghclient.FailureConclusion(check.Conclusion) {
 			return 1
 		}
+	}
+	if waitForCopilot && ghclient.CopilotReviewFails(copilotState) {
+		return 1
 	}
 	return 0
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -116,6 +116,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		oldSHA := m.headSHA
 		shaChanged := m.headSHA != "" && m.headSHA != msg.HeadSHA
 
 		m.prTitle = msg.Title
@@ -144,7 +145,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.copilotSubmittedAt = time.Time{}
 				m.copilotReviewComplete = false
 				m.copilotNotReqStreak = 0
-				debug.Log("copilot state reset on head SHA change", "old", m.headSHA, "new", msg.HeadSHA)
+				debug.Log("copilot state reset on head SHA change", "old", oldSHA, "new", msg.HeadSHA)
 			}
 			m.copilotPending = true
 			m.copilotReviewComplete = false

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -100,10 +100,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Poll Copilot review on its own cadence, gated on rate limit and
-		// the initial delay window (issue #409).
+		// the initial delay window (issue #409). copilotPollStartTime is
+		// PRInfoMsg-time + copilotInitialDelay; the first poll may fire only
+		// after that instant so GitHub has time to create the review request.
 		if m.waitForCopilot && m.copilotPending && !m.quitting &&
 			m.rateLimitRemaining >= minRateLimitForFetch &&
-			!m.copilotWaitStartTime.IsZero() && time.Now().After(m.copilotWaitStartTime) &&
+			!m.copilotPollStartTime.IsZero() && time.Now().After(m.copilotPollStartTime) &&
 			(m.copilotLastPoll.IsZero() || time.Since(m.copilotLastPoll) >= m.copilotPollInterval) {
 			cmds = append(cmds, fetchCopilotReview(m.ctx, m.token, m.owner, m.repo, m.prNumber, m.headSHA))
 		}
@@ -147,16 +149,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if shaChanged {
 				m.copilotState = ""
 				m.copilotStale = false
-				m.copilotSubmittedAt = time.Time{}
 				m.copilotReviewComplete = false
 				m.copilotNotReqStreak = 0
 				debug.Log("copilot state reset on head SHA change", "old", oldSHA, "new", msg.HeadSHA)
 			}
 			m.copilotPending = true
 			m.copilotReviewComplete = false
-			m.copilotWaitStartTime = time.Now().Add(m.copilotInitialDelay)
-			debug.Log("copilot gate armed, first poll after initial delay",
-				"delay", m.copilotInitialDelay, "wait_start", m.copilotWaitStartTime)
+			// copilotWaitStartTime bounds the total wall-clock wait for a
+			// Copilot review (copilot_max_wait), measured from PR-info time so
+			// the config knob means what it says. copilotPollStartTime is the
+			// initial-delay gate: the first poll may fire only after this
+			// instant, giving GitHub time to create the review request after a
+			// push. See copilotGateSatisfied and the TickMsg poll gate below.
+			m.copilotWaitStartTime = time.Now()
+			m.copilotPollStartTime = time.Now().Add(m.copilotInitialDelay)
+			debug.Log("copilot gate armed",
+				"wait_start", m.copilotWaitStartTime,
+				"poll_start", m.copilotPollStartTime,
+				"max_wait", m.copilotMaxWait,
+				"initial_delay", m.copilotInitialDelay)
 		}
 
 		return m, tea.Batch(cmds...)
@@ -434,7 +445,9 @@ func copilotGateSatisfied(m *Model) bool {
 	if m.copilotStale {
 		return true
 	}
-	// Max wait elapsed — stop waiting and proceed.
+	// Max wait elapsed (total wall-clock since PRInfoMsg) — stop waiting and
+	// proceed. copilot_max_wait measures from PR-info time, so this includes
+	// the initial-delay window (issue #409).
 	if !m.copilotWaitStartTime.IsZero() && time.Since(m.copilotWaitStartTime) >= m.copilotMaxWait {
 		debug.Log("copilot max wait elapsed, proceeding", "max_wait", m.copilotMaxWait)
 		return true
@@ -476,7 +489,6 @@ func (m *Model) handleCopilotReview(msg CopilotReviewMsg) (tea.Model, tea.Cmd) {
 
 	m.copilotState = msg.State
 	m.copilotStale = msg.Stale
-	m.copilotSubmittedAt = msg.SubmittedAt
 
 	if msg.Pending {
 		m.copilotPending = true
@@ -602,8 +614,6 @@ func fetchCopilotReview(ctx context.Context, token, owner, repo string, prNumber
 		}
 		return CopilotReviewMsg{
 			State:              review.State,
-			SubmittedAt:        review.SubmittedAt,
-			CommitOID:          review.CommitOID,
 			Stale:              review.Stale,
 			Pending:            review.Pending,
 			NotRequested:       review.NotRequested,

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 )
 
@@ -17,12 +18,12 @@ func makeModel() *Model {
 		rateLimitRemaining:      5000,
 		jobAverages:             make(map[string]time.Duration),
 		workflowAverages:        make(map[int64]map[string]time.Duration),
-		advSecMatchWorkflow:    make(map[string]int64),
+		advSecMatchWorkflow:     make(map[string]int64),
 		runIDToWorkflowID:       make(map[int64]int64),
 		fetchedWorkflowIDs:      make(map[int64]bool),
 		pendingWorkflowFetch:    make(map[int64]bool),
 		dispatchedWorkflowFetch: make(map[int64]bool),
-		seenCheckKeys:          make(map[string]bool),
+		seenCheckKeys:           make(map[string]bool),
 	}
 }
 
@@ -192,19 +193,19 @@ func TestHandleChecksUpdate(t *testing.T) {
 		wantChecksStored   bool
 	}{
 		{
-			name:               "error in message stores error and returns nil cmd",
-			msg:                ChecksUpdateMsg{Err: context.Canceled},
-			wantErr:            true,
-			wantExitCode:       0,
-			wantQuitting:       false,
-			wantChecksStored:   false,
+			name:             "error in message stores error and returns nil cmd",
+			msg:              ChecksUpdateMsg{Err: context.Canceled},
+			wantErr:          true,
+			wantExitCode:     0,
+			wantQuitting:     false,
+			wantChecksStored: false,
 		},
 		{
-			name:               "successful update stores check runs",
-			msg:                ChecksUpdateMsg{CheckRuns: []ghclient.CheckRunInfo{{Status: "in_progress", Conclusion: ""}}, RateLimitRemaining: 5000},
-			rateLimit:          5000,
-			wantErr:            false,
-			wantChecksStored:   true,
+			name:             "successful update stores check runs",
+			msg:              ChecksUpdateMsg{CheckRuns: []ghclient.CheckRunInfo{{Status: "in_progress", Conclusion: ""}}, RateLimitRemaining: 5000},
+			rateLimit:        5000,
+			wantErr:          false,
+			wantChecksStored: true,
 		},
 		{
 			name:               "all checks complete sets exit code 0 on success",
@@ -897,12 +898,12 @@ func TestRediscoveryOnNewJobs(t *testing.T) {
 		m.jobAverages = map[string]time.Duration{"build": time.Minute}
 
 		initialCheck := ghclient.CheckRunInfo{
-			Name:           "build",
-			Status:         "completed",
-			Conclusion:     "success",
-			WorkflowRunID:  100,
-			WorkflowID:     200,
-			DetailsURL:     "https://github.com/test/test/actions/runs/100/job/1",
+			Name:          "build",
+			Status:        "completed",
+			Conclusion:    "success",
+			WorkflowRunID: 100,
+			WorkflowID:    200,
+			DetailsURL:    "https://github.com/test/test/actions/runs/100/job/1",
 		}
 		key := checkKey(initialCheck)
 		m.seenCheckKeys[key] = true
@@ -911,10 +912,10 @@ func TestRediscoveryOnNewJobs(t *testing.T) {
 		m.pendingWorkflowFetch = map[int64]bool{}
 
 		newCheck := ghclient.CheckRunInfo{
-			Name:           "test",
-			Status:         "in_progress",
-			WorkflowRunID:  300,
-			DetailsURL:     "https://github.com/test/test/actions/runs/300/job/2",
+			Name:          "test",
+			Status:        "in_progress",
+			WorkflowRunID: 300,
+			DetailsURL:    "https://github.com/test/test/actions/runs/300/job/2",
 		}
 
 		msg := ChecksUpdateMsg{
@@ -941,12 +942,12 @@ func TestRediscoveryOnNewJobs(t *testing.T) {
 		m.pendingWorkflowFetch = map[int64]bool{}
 
 		existingCheck := ghclient.CheckRunInfo{
-			Name:           "build",
-			Status:         "completed",
-			Conclusion:     "success",
-			WorkflowRunID:  100,
-			WorkflowID:     200,
-			DetailsURL:     "https://github.com/test/test/actions/runs/100/job/1",
+			Name:          "build",
+			Status:        "completed",
+			Conclusion:    "success",
+			WorkflowRunID: 100,
+			WorkflowID:    200,
+			DetailsURL:    "https://github.com/test/test/actions/runs/100/job/1",
 		}
 		key := checkKey(existingCheck)
 		m.seenCheckKeys[key] = true
@@ -1119,7 +1120,7 @@ func TestAdvSecAliasOnRediscovery(t *testing.T) {
 		}
 		m.jobAverages = map[string]time.Duration{
 			"Analyze (go)": 2 * time.Minute,
-			"CodeQL":        3 * time.Minute,
+			"CodeQL":       3 * time.Minute,
 		}
 		m.checkRuns = []ghclient.CheckRunInfo{
 			{Name: "Analyze (go)", WorkflowRunID: 100, WorkflowID: 789, WorkflowName: "CodeQL", DetailsURL: "https://github.com/test/test/actions/runs/100/job/1"},
@@ -1322,8 +1323,8 @@ func TestHandleCopilotReview(t *testing.T) {
 		m.checkRuns = completedChecks
 
 		model, _ := m.handleCopilotReview(CopilotReviewMsg{
-			Stale:         true,
-			NotRequested:  true,
+			Stale:        true,
+			NotRequested: true,
 		})
 		result := model.(*Model)
 		if result.copilotPending {
@@ -1380,6 +1381,87 @@ func TestHandleCopilotReview(t *testing.T) {
 			t.Error("should stay pending on error")
 		}
 	})
+
+	t.Run("cold start: PRInfoMsg arms gate, TickMsg fires first poll after initial delay", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotInitialDelay = 50 * time.Millisecond
+		m.copilotPollInterval = 10 * time.Millisecond
+		m.copilotMaxWait = 5 * time.Second
+		m.prNumber = 42
+		m.headSHA = "abc123"
+
+		// PRInfoMsg should arm the gate (copilotPending=true) and set
+		// copilotWaitStartTime to now + initialDelay, but NOT dispatch a
+		// fetch. The gate must remain unsatisfied while pending.
+		model, _ := m.Update(PRInfoMsg{
+			Number:         42,
+			Title:          "test",
+			HeadSHA:        "abc123",
+			HeadCommitTime: time.Now(),
+		})
+		result := model.(Model)
+		if !result.copilotPending {
+			t.Fatal("copilotPending should be true after PRInfoMsg (gate armed)")
+		}
+		if result.copilotWaitStartTime.IsZero() {
+			t.Fatal("copilotWaitStartTime should be set after PRInfoMsg")
+		}
+		if copilotGateSatisfied(&result) {
+			t.Error("gate should not be satisfied while pending and within max-wait")
+		}
+
+		// Wait for the initial-delay window to elapse, then drive a TickMsg.
+		// The tick should batch a copilot fetch in addition to the two
+		// baseline cmds (fetchCheckRuns + tick).
+		time.Sleep(60 * time.Millisecond)
+		_, cmd := result.Update(TickMsg(time.Now()))
+		if n := countBatchedCmds(cmd); n < 3 {
+			t.Errorf("TickMsg after initial delay should dispatch copilot fetch; got %d cmds (want >=3)", n)
+		}
+	})
+
+	t.Run("cold start: TickMsg before initial delay does not poll copilot", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotInitialDelay = 1 * time.Hour // far in the future
+		m.copilotPollInterval = 10 * time.Millisecond
+		m.copilotMaxWait = 5 * time.Second
+		m.prNumber = 42
+		m.headSHA = "abc123"
+
+		model, _ := m.Update(PRInfoMsg{
+			Number:         42,
+			Title:          "test",
+			HeadSHA:        "abc123",
+			HeadCommitTime: time.Now(),
+		})
+		result := model.(Model)
+		if !result.copilotPending {
+			t.Fatal("copilotPending should be true after PRInfoMsg")
+		}
+
+		// TickMsg immediately after PRInfoMsg: initial-delay window not
+		// elapsed, so only the 2 baseline cmds (fetchCheckRuns + tick).
+		_, cmd := result.Update(TickMsg(time.Now()))
+		if n := countBatchedCmds(cmd); n != 2 {
+			t.Errorf("TickMsg before initial delay should not poll copilot; got %d cmds (want 2)", n)
+		}
+	})
+}
+
+// countBatchedCmds executes a tea.Cmd and, if it returns a tea.BatchMsg,
+// returns the number of batched commands. Returns 1 for a single (non-batch)
+// command and 0 for nil.
+func countBatchedCmds(cmd tea.Cmd) int {
+	if cmd == nil {
+		return 0
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		return len(batch)
+	}
+	return 1
 }
 
 func TestDetermineExitCode_Copilot(t *testing.T) {

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1391,9 +1391,11 @@ func TestHandleCopilotReview(t *testing.T) {
 		m.prNumber = 42
 		m.headSHA = "abc123"
 
-		// PRInfoMsg should arm the gate (copilotPending=true) and set
-		// copilotWaitStartTime to now + initialDelay, but NOT dispatch a
-		// fetch. The gate must remain unsatisfied while pending.
+		// PRInfoMsg should arm the gate (copilotPending=true), set
+		// copilotWaitStartTime to now (max-wait measured from PR-info time),
+		// and copilotPollStartTime to now + initialDelay, but NOT dispatch a
+		// fetch. The gate must remain unsatisfied while pending and within
+		// max-wait.
 		model, _ := m.Update(PRInfoMsg{
 			Number:         42,
 			Title:          "test",
@@ -1407,14 +1409,21 @@ func TestHandleCopilotReview(t *testing.T) {
 		if result.copilotWaitStartTime.IsZero() {
 			t.Fatal("copilotWaitStartTime should be set after PRInfoMsg")
 		}
+		if result.copilotPollStartTime.IsZero() {
+			t.Fatal("copilotPollStartTime should be set after PRInfoMsg")
+		}
+		if !result.copilotPollStartTime.After(result.copilotWaitStartTime) {
+			t.Error("copilotPollStartTime should be after copilotWaitStartTime (now + initialDelay vs now)")
+		}
 		if copilotGateSatisfied(&result) {
 			t.Error("gate should not be satisfied while pending and within max-wait")
 		}
 
 		// Wait for the initial-delay window to elapse, then drive a TickMsg.
 		// The tick should batch a copilot fetch in addition to the two
-		// baseline cmds (fetchCheckRuns + tick).
-		time.Sleep(60 * time.Millisecond)
+		// baseline cmds (fetchCheckRuns + tick). Margin is 150ms to avoid
+		// flakes on loaded CI runners (10ms was too tight).
+		time.Sleep(200 * time.Millisecond)
 		_, cmd := result.Update(TickMsg(time.Now()))
 		if n := countBatchedCmds(cmd); n < 3 {
 			t.Errorf("TickMsg after initial delay should dispatch copilot fetch; got %d cmds (want >=3)", n)

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -172,7 +172,7 @@ func TestDetermineExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := determineExitCode(tt.checks)
+			got := determineExitCode(tt.checks, "", false)
 			if got != tt.want {
 				t.Errorf("determineExitCode() = %v, want %v", got, tt.want)
 			}
@@ -1211,4 +1211,220 @@ func TestPresumedAverages(t *testing.T) {
 			t.Errorf("jobAverages[DCO] should not be set with nil presumedAverages, got %v", result.jobAverages["DCO"])
 		}
 	})
+}
+
+func TestCopilotGateSatisfied(t *testing.T) {
+	tests := []struct {
+		name           string
+		waitForCopilot bool
+		pending        bool
+		stale          bool
+		maxWaitElapsed bool
+		want           bool
+	}{
+		{name: "disabled", waitForCopilot: false, want: true},
+		{name: "not pending", waitForCopilot: true, pending: false, want: true},
+		{name: "pending and not stale", waitForCopilot: true, pending: true, stale: false, want: false},
+		{name: "pending but stale", waitForCopilot: true, pending: true, stale: true, want: true},
+		{name: "pending max wait elapsed", waitForCopilot: true, pending: true, maxWaitElapsed: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				waitForCopilot: tt.waitForCopilot,
+				copilotPending: tt.pending,
+				copilotStale:   tt.stale,
+			}
+			if tt.maxWaitElapsed {
+				m.copilotWaitStartTime = time.Now().Add(-200 * time.Second)
+				m.copilotMaxWait = 180 * time.Second
+			} else if tt.pending {
+				m.copilotWaitStartTime = time.Now()
+				m.copilotMaxWait = 180 * time.Second
+			}
+			if got := copilotGateSatisfied(m); got != tt.want {
+				t.Errorf("copilotGateSatisfied() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleCopilotReview(t *testing.T) {
+	completedChecks := []ghclient.CheckRunInfo{{Status: "completed", Conclusion: "success"}}
+
+	t.Run("approved review completes and can quit", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+		m.checksComplete = true
+		m.checkRuns = completedChecks
+
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			State: "approved",
+		})
+		result := model.(*Model)
+		if result.copilotPending {
+			t.Error("copilotPending should be false after approved review")
+		}
+		if !result.copilotReviewComplete {
+			t.Error("copilotReviewComplete should be true after approved review")
+		}
+		if !result.quitting {
+			t.Error("should quit when checks complete and copilot approved")
+		}
+		if result.exitCode != 0 {
+			t.Errorf("exitCode = %d, want 0", result.exitCode)
+		}
+	})
+
+	t.Run("changes_requested sets exit code 1", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+		m.checksComplete = true
+		m.checkRuns = completedChecks
+
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			State: "changes_requested",
+		})
+		result := model.(*Model)
+		if result.exitCode != 1 {
+			t.Errorf("exitCode = %d, want 1 for changes_requested", result.exitCode)
+		}
+		if !result.quitting {
+			t.Error("should quit when checks complete and copilot changes_requested")
+		}
+	})
+
+	t.Run("pending review stays pending", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			State:   "pending",
+			Pending: true,
+		})
+		result := model.(*Model)
+		if !result.copilotPending {
+			t.Error("copilotPending should remain true")
+		}
+		if result.quitting {
+			t.Error("should not quit while copilot pending")
+		}
+	})
+
+	t.Run("stale review does not block", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+		m.checksComplete = true
+		m.checkRuns = completedChecks
+
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			Stale:         true,
+			NotRequested:  true,
+		})
+		result := model.(*Model)
+		if result.copilotPending {
+			t.Error("copilotPending should be false after stale")
+		}
+		if !result.quitting {
+			t.Error("should quit with stale review when checks complete")
+		}
+	})
+
+	t.Run("not requested requires two consecutive", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+
+		// First not-requested: should stay pending
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			NotRequested: true,
+		})
+		result := model.(*Model)
+		if !result.copilotPending {
+			t.Error("should stay pending after first not-requested")
+		}
+		if result.copilotNotReqStreak != 1 {
+			t.Errorf("streak = %d, want 1", result.copilotNotReqStreak)
+		}
+
+		// Second not-requested: should complete
+		model, _ = result.handleCopilotReview(CopilotReviewMsg{
+			NotRequested: true,
+		})
+		result = model.(*Model)
+		if result.copilotPending {
+			t.Error("should not be pending after two consecutive not-requested")
+		}
+		if !result.copilotReviewComplete {
+			t.Error("copilotReviewComplete should be true")
+		}
+	})
+
+	t.Run("error stores error and stays pending", func(t *testing.T) {
+		m := makeModel()
+		m.waitForCopilot = true
+		m.copilotPending = true
+
+		model, _ := m.handleCopilotReview(CopilotReviewMsg{
+			Err: context.Canceled,
+		})
+		result := model.(*Model)
+		if result.err == nil {
+			t.Error("should store error")
+		}
+		if !result.copilotPending {
+			t.Error("should stay pending on error")
+		}
+	})
+}
+
+func TestDetermineExitCode_Copilot(t *testing.T) {
+	tests := []struct {
+		name           string
+		checks         []ghclient.CheckRunInfo
+		copilotState   string
+		waitForCopilot bool
+		want           int
+	}{
+		{
+			name:           "copilot changes_requested fails",
+			checks:         []ghclient.CheckRunInfo{{Status: "completed", Conclusion: "success"}},
+			copilotState:   "changes_requested",
+			waitForCopilot: true,
+			want:           1,
+		},
+		{
+			name:           "copilot approved does not fail",
+			checks:         []ghclient.CheckRunInfo{{Status: "completed", Conclusion: "success"}},
+			copilotState:   "approved",
+			waitForCopilot: true,
+			want:           0,
+		},
+		{
+			name:           "copilot disabled ignores state",
+			checks:         []ghclient.CheckRunInfo{{Status: "completed", Conclusion: "success"}},
+			copilotState:   "changes_requested",
+			waitForCopilot: false,
+			want:           0,
+		},
+		{
+			name:           "check failure takes precedence",
+			checks:         []ghclient.CheckRunInfo{{Status: "completed", Conclusion: "failure"}},
+			copilotState:   "approved",
+			waitForCopilot: true,
+			want:           1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineExitCode(tt.checks, tt.copilotState, tt.waitForCopilot)
+			if got != tt.want {
+				t.Errorf("determineExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 	"github.com/fini-net/gh-observer/internal/timing"
+	"github.com/mattn/go-runewidth"
 )
 
 // View renders the current state
@@ -52,6 +53,12 @@ func (m Model) View() tea.View {
 
 		fmt.Fprintf(&b, "%s %s\n", prInfo, utcTime)
 		fmt.Fprintf(&b, "%s\n", updatedLine)
+
+		// Copilot review status line (issue #409)
+		if m.waitForCopilot {
+			b.WriteString(m.renderCopilotStatusLine())
+		}
+
 		b.WriteString("\n")
 	}
 
@@ -76,6 +83,13 @@ func (m Model) View() tea.View {
 		if (check.Conclusion == "failure" || check.Conclusion == "timed_out") && len(check.Annotations) > 0 {
 			b.WriteString(m.renderErrorBox(check, widths))
 		}
+	}
+
+	// Copilot review row (issue #409) — no queue/duration/avg columns since
+	// reviews have no startedAt/completedAt timestamps. Rendered as a simple
+	// icon + label line aligned under the check table's icon column.
+	if m.waitForCopilot && m.copilotReviewComplete && m.copilotState != "" {
+		b.WriteString(m.renderCopilotReviewRow(widths))
 	}
 
 	b.WriteString("\n")
@@ -219,6 +233,66 @@ func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) 
 
 	// Assemble line: [queue][1 space][icon][1 space][name][2 spaces][duration][2 spaces][avg][newline]
 	return queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + styledAvg + "\n"
+}
+
+// renderCopilotStatusLine renders the Copilot review status under the PR
+// header: a spinner + elapsed line while pending, or a yellow stale warning
+// (issue #409).
+func (m Model) renderCopilotStatusLine() string {
+	if m.copilotPending && !m.copilotStale {
+		elapsed := time.Since(m.copilotWaitStartTime)
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		return fmt.Sprintf("%s %s\n", m.spinner.View(),
+			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))
+	}
+	if m.copilotStale {
+		shortHead := m.headSHA
+		if len(shortHead) > 7 {
+			shortHead = shortHead[:7]
+		}
+		return m.styles.Running.Render(
+			fmt.Sprintf("⚠ Copilot review is stale (HEAD is %s) — refresh or re-request\n", shortHead))
+	}
+	return ""
+}
+
+// renderCopilotReviewRow renders the completed Copilot review as a row in the
+// check table with an icon by state, but no queue-latency or runtime columns
+// (reviews have no startedAt/completedAt — issue #409).
+func (m Model) renderCopilotReviewRow(widths ColumnWidths) string {
+	icon := GetCopilotReviewIcon(m.copilotState)
+
+	var style = m.styles.Queued
+	switch m.copilotState {
+	case "approved":
+		style = m.styles.Success
+	case "changes_requested":
+		style = m.styles.Failure
+	case "commented":
+		style = m.styles.Info
+	case "dismissed":
+		style = m.styles.Queued
+	}
+
+	// Pad the queue column with spaces (reviews have no queue latency) and
+	// render the name as "Copilot / <state>" to match the Workflow/Job format.
+	queueCol := strings.Repeat(" ", widths.QueueWidth)
+	nameCol := fmt.Sprintf("Copilot / %s", m.copilotState)
+
+	// Apply same width-based truncation as check names
+	if runewidth.StringWidth(nameCol) > widths.NameWidth {
+		nameCol = runewidth.Truncate(nameCol, widths.NameWidth, "…")
+	}
+	namePadding := max(widths.NameWidth-runewidth.StringWidth(nameCol), 0)
+	paddedName := nameCol + strings.Repeat(" ", namePadding)
+
+	// No duration or avg columns — pad with spaces to align with the table
+	durPad := strings.Repeat(" ", widths.DurationWidth)
+	avgPad := strings.Repeat(" ", widths.AvgWidth)
+
+	return queueCol + " " + style.Render(icon) + " " + style.Render(paddedName) + "  " + durPad + "  " + avgPad + "\n"
 }
 
 // renderStartupPhase shows helpful message during GitHub Actions startup delay

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -242,7 +242,12 @@ func (m Model) renderCopilotStatusLine() string {
 	if m.copilotPending && !m.copilotStale {
 		elapsed := time.Since(m.copilotWaitStartTime)
 		if elapsed < 0 {
-			elapsed = 0
+			// Still inside the initial-delay window (copilotWaitStartTime is
+			// set to now + copilotInitialDelay). Polling hasn't started yet, so
+			// show a distinct message rather than clamping to "0s elapsed".
+			remaining := -elapsed
+			return fmt.Sprintf("%s %s\n", m.spinner.View(),
+				m.styles.Running.Render(fmt.Sprintf("Copilot review queued, polling in %s…", timing.FormatDuration(remaining))))
 		}
 		return fmt.Sprintf("%s %s\n", m.spinner.View(),
 			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -240,15 +240,15 @@ func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) 
 // (issue #409).
 func (m Model) renderCopilotStatusLine() string {
 	if m.copilotPending && !m.copilotStale {
-		elapsed := time.Since(m.copilotWaitStartTime)
-		if elapsed < 0 {
-			// Still inside the initial-delay window (copilotWaitStartTime is
-			// set to now + copilotInitialDelay). Polling hasn't started yet, so
-			// show a distinct message rather than clamping to "0s elapsed".
-			remaining := -elapsed
+		remaining := time.Until(m.copilotPollStartTime)
+		if remaining > 0 {
+			// Still inside the initial-delay window (copilotPollStartTime is
+			// set to PRInfoMsg-time + copilotInitialDelay). Polling hasn't
+			// started yet, so show a countdown rather than "0s elapsed".
 			return fmt.Sprintf("%s %s\n", m.spinner.View(),
 				m.styles.Running.Render(fmt.Sprintf("Copilot review queued, polling in %s…", timing.FormatDuration(remaining))))
 		}
+		elapsed := time.Since(m.copilotPollStartTime)
 		return fmt.Sprintf("%s %s\n", m.spinner.View(),
 			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))
 	}

--- a/main.go
+++ b/main.go
@@ -245,11 +245,11 @@ func runPRMode(ctx context.Context, token string, parsed runArgs, cfg *config.Co
 
 	// Check if running in a terminal
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		return runSnapshot(ctx, token, owner, repo, prNumber, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
+		return runSnapshot(ctx, token, owner, repo, prNumber, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations(), cfg.WaitForCopilot)
 	}
 
 	// Create model
-	model := tui.NewModel(ctx, token, owner, repo, prNumber, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations())
+	model := tui.NewModel(ctx, token, owner, repo, prNumber, cfg.RefreshInterval, styles, cfg.EnableLinks, quickFlag, cfg.PresumedAveragesDurations(), cfg.WaitForCopilot, cfg.CopilotMaxWait, cfg.CopilotPollInterval, cfg.CopilotInitialDelay)
 
 	// Run TUI
 	p := tea.NewProgram(model)
@@ -329,7 +329,7 @@ func runRepoMode(ctx context.Context, cfg *config.Config, styles tui.Styles, own
 }
 
 // runSnapshot prints a one-time snapshot of PR check status (non-interactive mode)
-func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, enableLinks bool, quick bool, presumedAverages map[string]time.Duration) int {
+func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, enableLinks bool, quick bool, presumedAverages map[string]time.Duration, waitForCopilot bool) int {
 	client, err := ghclient.NewClient(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create GitHub client: %v\n", err)
@@ -398,6 +398,25 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 
 		if check.Status == "completed" {
 			if ghclient.FailureConclusion(check.Conclusion) {
+				exitCode = 1
+			}
+		}
+	}
+
+	// Copilot review snapshot (issue #409)
+	if waitForCopilot {
+		review, _, copilotErr := ghclient.FetchCopilotReview(ctx, token, owner, repo, prNumber, prInfo.HeadSHA)
+		if copilotErr != nil {
+			fmt.Printf("Copilot: unavailable (%v)\n", copilotErr)
+		} else if review.NotRequested && !review.Stale {
+			fmt.Println("Copilot: not requested")
+		} else if review.Stale {
+			fmt.Println("Copilot: in progress (stale)")
+		} else if review.Pending {
+			fmt.Println("Copilot: in progress")
+		} else {
+			fmt.Printf("Copilot: %s\n", review.State)
+			if ghclient.CopilotReviewFails(review.State) {
 				exitCode = 1
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -411,7 +411,7 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 		} else if review.NotRequested && !review.Stale {
 			fmt.Println("Copilot: not requested")
 		} else if review.Stale {
-			fmt.Println("Copilot: in progress (stale)")
+			fmt.Println("Copilot: stale (review targets old commit)")
 		} else if review.Pending {
 			fmt.Println("Copilot: in progress")
 		} else {


### PR DESCRIPTION
Fixes #409 

<!-- PR_BODY_DONE_START -->
## Done

- 🛩️ [src] show copilot reviews like they are an action
- 🐛 [tui] fix copilot gate: arm pending in PRInfoMsg, poll via tick after initial delay
- 🐛 [gh] fix parseCopilotReview: don't set Stale when a fresh review is pending
- 🐛 [tui] fix debug log printing new SHA as 'old' on head SHA change
- 🐛 [main] fix misleading 'in progress (stale)' snapshot output
- 🔒 [gh] add int32 bounds check for GraphQL prNumber conversion
- 🧹 [test] wire up unused submittedAt param in makeReviewNode helper
- 🐛 [gh] fix invalid orderBy in Copilot review GraphQL query
- 🐛 [gh] fetch newest 25 Copilot reviews via reviews(last: 25)
- 🧹 [tui] drop dead Copilot state and measure max_wait from PR-info time

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
