### PR TITLE
🛬 [src] copilot reviews are displayed like other github actions running

### DIFF
--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -39,7 +39,17 @@ type Annotation struct {
 	AnnotationLevel string
 }
 
-// CheckRunInfo contains enriched check run data with workflow name
+// CheckRunInfo contains enriched check run data with workflow name.
+//
+// Kind discriminates the row type. The zero value ("") denotes a regular
+// check run sourced from GraphQL/REST. "review" denotes a synthetic row
+// representing a Copilot code review; in that case ReviewState carries the
+// review state vocabulary (pending/approved/changes_requested/commented/
+// dismissed/stale) which is intentionally distinct from Status/Conclusion
+// so that timing and conclusion helpers remain untouched. Synthetic review
+// rows must not participate in timing calculations: StartedAt is used only
+// to drive the in_progress runtime display while a review is pending, and
+// CompletedAt stays nil.
 type CheckRunInfo struct {
 	Name          string
 	WorkflowName  string
@@ -53,6 +63,8 @@ type CheckRunInfo struct {
 	Annotations   []Annotation
 	WorkflowRunID int64
 	WorkflowID    int64
+	Kind         string
+	ReviewState  string
 }
 
 // contextNode represents a union type in the StatusCheckRollup

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -63,8 +63,8 @@ type CheckRunInfo struct {
 	Annotations   []Annotation
 	WorkflowRunID int64
 	WorkflowID    int64
-	Kind         string
-	ReviewState  string
+	Kind          string
+	ReviewState   string
 }
 
 // contextNode represents a union type in the StatusCheckRollup

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -96,10 +96,17 @@ func GetCheckIcon(status, conclusion string) string {
 	}
 }
 
-// GetCopilotReviewIcon returns the icon for a Copilot review row, keyed on
-// review state (not check status/conclusion). Reviews are a distinct concept
-// from check runs, so this is separate from GetCheckIcon (issue #409).
-func GetCopilotReviewIcon(state string) string {
+// GetCopilotReviewIcon returns the icon for a Copilot review row.
+//
+// Reviews are a distinct concept from check runs, so this is separate
+// from GetCheckIcon (issue #409). The terminal-state icons (✓/✗/💬/⊘/⚠)
+// are keyed on review state, but the pending sub-states need to
+// distinguish queued (still inside copilotInitialDelay, duration column
+// shows "in 15s") from in_progress (actively polling) — keying only on
+// ReviewState would show the in-progress spinner ◐ while the countdown
+// reads "in 15s", which is mixed signals. So pending rows fall through
+// to a status check: queued → ⏸, in_progress → ◐ (matching GetCheckIcon).
+func GetCopilotReviewIcon(state, status string) string {
 	switch state {
 	case "approved":
 		return "✓"
@@ -109,10 +116,13 @@ func GetCopilotReviewIcon(state string) string {
 		return "💬"
 	case "dismissed":
 		return "⊘"
-	case "pending":
-		return "◐"
 	case "stale":
 		return "⚠"
+	case "pending":
+		if status == "queued" {
+			return "⏸"
+		}
+		return "◐"
 	default:
 		return "?"
 	}

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -100,6 +100,8 @@ func GetCopilotReviewIcon(state string) string {
 		return "⊘"
 	case "pending":
 		return "◐"
+	case "stale":
+		return "⚠"
 	default:
 		return "?"
 	}

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -25,6 +25,12 @@ type ColumnWidths struct {
 // drift on the cap and produce different geometries for the same row.
 const maxCheckNameWidth = 60
 
+// copilotRowKind is the Kind discriminator for synthetic Copilot review
+// rows. Shared by renderCheckRun (which dispatches on it) and
+// buildCopilotCheckRun (which sets it) so the two call sites can't drift
+// on the literal string — same rationale as maxCheckNameWidth above.
+const copilotRowKind = "review"
+
 // FormatQueueLatency returns the queue time text or placeholder
 func FormatQueueLatency(check ghclient.CheckRunInfo, headCommitTime time.Time) string {
 	if check.Status == "queued" {

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -20,6 +20,11 @@ type ColumnWidths struct {
 	AvgWidth      int // Right-aligned historical average
 }
 
+// maxCheckNameWidth caps the left-aligned name column. Shared by
+// CalculateColumnWidths and widenForCopilotRow so the two paths can't
+// drift on the cap and produce different geometries for the same row.
+const maxCheckNameWidth = 60
+
 // FormatQueueLatency returns the queue time text or placeholder
 func FormatQueueLatency(check ghclient.CheckRunInfo, headCommitTime time.Time) string {
 	if check.Status == "queued" {
@@ -188,7 +193,6 @@ func FormatAvg(check ghclient.CheckRunInfo, jobAverages map[string]time.Duration
 func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime time.Time, jobAverages map[string]time.Duration) ColumnWidths {
 	const (
 		minNameWidth = 20
-		maxNameWidth = 60
 		minTimeWidth = 5
 	)
 
@@ -207,10 +211,10 @@ func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime tim
 
 		name := FormatCheckName(check)
 		nameLen := runewidth.StringWidth(name)
-		if nameLen > widths.NameWidth && nameLen <= maxNameWidth {
+		if nameLen > widths.NameWidth && nameLen <= maxCheckNameWidth {
 			widths.NameWidth = nameLen
-		} else if nameLen > maxNameWidth {
-			widths.NameWidth = maxNameWidth
+		} else if nameLen > maxCheckNameWidth {
+			widths.NameWidth = maxCheckNameWidth
 		}
 
 		durationText := FormatDuration(check)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -246,14 +246,14 @@ func (m Model) renderSummary(check ghclient.CheckRunInfo, widths ColumnWidths) s
 // renderCheckRun displays a single check run with aligned columns.
 //
 // For regular check runs (Kind == "") the four columns are populated from
-// timing data as before. For Copilot review rows (Kind == "review") the
-// queue and avg columns are left blank (reviews have no queue latency or
-// historical averages), the icon and style come from the review state, and
-// the duration column either shows a countdown (while queued in the
+// timing data as before. For Copilot review rows (Kind == copilotRowKind)
+// the queue and avg columns are left blank (reviews have no queue latency
+// or historical averages), the icon and style come from the review state,
+// and the duration column either shows a countdown (while queued in the
 // initial-delay window), an elapsed runtime (while pending), or "-"
 // (once complete — reviews expose no timestamps for FinalDuration).
 func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) string {
-	if check.Kind == "review" {
+	if check.Kind == copilotRowKind {
 		return m.renderCopilotReviewCheckRun(check, widths)
 	}
 	status := check.Status
@@ -416,7 +416,7 @@ func (m Model) buildCopilotCheckRun() *ghclient.CheckRunInfo {
 	}
 
 	const (
-		kind       = "review"
+		kind       = copilotRowKind
 		workflow   = "Copilot"
 		name       = "Review"
 		detailsURL = ""

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -94,13 +94,13 @@ func (m Model) View() tea.View {
 		checkLine := m.renderCheckRun(check, widths)
 		b.WriteString(checkLine)
 
-	// Render the summary line for failed checks. (Synthetic Copilot
-	// review rows never appear in m.checkRuns — they are rendered at the
-	// separate copilotRow site below — so the summary path for them is
-	// also reached there, not here.)
-	if check.Summary != "" && (check.Conclusion == "failure" || check.Conclusion == "timed_out") {
-		b.WriteString(m.renderSummary(check, widths))
-	}
+		// Render the summary line for failed checks. (Synthetic Copilot
+		// review rows never appear in m.checkRuns — they are rendered at the
+		// separate copilotRow site below — so the summary path for them is
+		// also reached there, not here.)
+		if check.Summary != "" && (check.Conclusion == "failure" || check.Conclusion == "timed_out") {
+			b.WriteString(m.renderSummary(check, widths))
+		}
 
 		if (check.Conclusion == "failure" || check.Conclusion == "timed_out") && len(check.Annotations) > 0 {
 			b.WriteString(m.renderErrorBox(check, widths))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -70,6 +70,13 @@ func (m Model) View() tea.View {
 	// evaluate differently between the two calls if the countdown crosses
 	// zero mid-render — leading the widths calc and the rendered row to
 	// disagree on status.
+	//
+	// This call site is intentionally below the len(m.checkRuns)==0 early
+	// return above: during the Actions startup phase the Copilot row is not
+	// rendered (see the comment by renderCopilotStatusLine below for why
+	// that tradeoff is acceptable). Hoisting it above the early return would
+	// resurface the row during startup but would also require re-evaluating
+	// the column-width path for an empty checkRuns slice.
 	copilotRow := m.buildCopilotCheckRun()
 
 	// Ensure the column geometry accommodates the synthetic Copilot review
@@ -111,11 +118,30 @@ func (m Model) View() tea.View {
 
 	// Copilot review status line (issue #409). Rendered below the Copilot
 	// table row, not in the header, so the spinner/countdown line sits
-	// visually next to the row it describes. Note: this call site is
-	// below the len(m.checkRuns)==0 early return above, so during the
-	// startup phase (before Actions checks appear) the status line is
-	// not rendered — Copilot polling is armed in PRInfoMsg independently
-	// of check discovery and typically resolves before checks appear.
+	// visually next to the row it describes.
+	//
+	// Startup-phase tradeoff: this call site is below the
+	// len(m.checkRuns)==0 early return above, so during the Actions startup
+	// phase (before any check appears, typically 30-90s after PR creation)
+	// NEITHER the synthetic Copilot row NOR this status line is rendered.
+	// That reopens a narrow window that an earlier revision (commit dd23bdd)
+	// had closed for the status line. We accept this because:
+	//   - copilotWaitStartTime is armed in PRInfoMsg, which fires before
+	//     any check appears, so the suppression window is bounded by how
+	//     long Actions takes to surface its first check, not by Copilot.
+	//   - For that window the only information lost is the initial-delay
+	//     countdown ("Copilot review queued, polling in 15s…"), which is
+	//     itself bounded by copilot_initial_delay (default 15s) and is
+	//     low-value: the user already knows from the PR-title block that a
+	//     watch is running, and the row would only show "⏸ in 15s" before
+	//     transitioning to "◐ in progress…".
+	//   - Polling is armed in PRInfoMsg independently of this render path,
+	//     so suppression here is display-only and does not delay the first
+	//     Copilot fetch.
+	// If user feedback changes the calculus, surface the status line from
+	// renderStartupPhase() (which IS reached during the startup phase) rather
+	// than hoisting this call above the early return, so the table geometry
+	// path is not perturbed for an empty checkRuns slice.
 	// renderCopilotStatusLine self-gates via copilotWaitStartTime and
 	// returns "" for terminal non-stale states.
 	if m.waitForCopilot {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -54,11 +54,6 @@ func (m Model) View() tea.View {
 		fmt.Fprintf(&b, "%s %s\n", prInfo, utcTime)
 		fmt.Fprintf(&b, "%s\n", updatedLine)
 
-		// Copilot review status line (issue #409)
-		if m.waitForCopilot {
-			b.WriteString(m.renderCopilotStatusLine())
-		}
-
 		b.WriteString("\n")
 	}
 
@@ -67,6 +62,13 @@ func (m Model) View() tea.View {
 	}
 
 	widths := CalculateColumnWidths(m.checkRuns, m.headCommitTime, m.jobAverages)
+
+	// Ensure the column geometry accommodates the synthetic Copilot review
+	// row when present, so the row never truncates its own name or the
+	// countdown/elapsed text in the duration column.
+	if copilotRow := m.buildCopilotCheckRun(); copilotRow != nil {
+		widths = widenForCopilotRow(widths, *copilotRow)
+	}
 
 	headerQueue, headerName, headerDuration, headerAvg := FormatHeaderColumns(widths)
 	b.WriteString(m.styles.Header.Render(fmt.Sprintf("%s   %s  %s  %s\n", headerQueue, headerName, headerDuration, headerAvg)))
@@ -85,11 +87,12 @@ func (m Model) View() tea.View {
 		}
 	}
 
-	// Copilot review row (issue #409) — no queue/duration/avg columns since
-	// reviews have no startedAt/completedAt timestamps. Rendered as a simple
-	// icon + label line aligned under the check table's icon column.
-	if m.waitForCopilot && m.copilotReviewComplete && m.copilotState != "" {
-		b.WriteString(m.renderCopilotReviewRow(widths))
+	// Copilot review row (issue #409). The row is display-only: it never
+	// enters m.checkRuns, so allChecksComplete, SortCheckRuns, and
+	// determineExitCode are unaffected. It is always rendered last,
+	// regardless of state, to keep its position predictable.
+	if copilotRow := m.buildCopilotCheckRun(); copilotRow != nil {
+		b.WriteString(m.renderCheckRun(*copilotRow, widths))
 	}
 
 	b.WriteString("\n")
@@ -180,8 +183,19 @@ func (m Model) renderSummary(check ghclient.CheckRunInfo, widths ColumnWidths) s
 	return fmt.Sprintf("%s%s\n", strings.Repeat(" ", indent), m.styles.Description.Render(check.Summary))
 }
 
-// renderCheckRun displays a single check run with aligned columns
+// renderCheckRun displays a single check run with aligned columns.
+//
+// For regular check runs (Kind == "") the four columns are populated from
+// timing data as before. For Copilot review rows (Kind == "review") the
+// queue and avg columns are left blank (reviews have no queue latency or
+// historical averages), the icon and style come from the review state, and
+// the duration column either shows a countdown (while queued in the
+// initial-delay window), an elapsed runtime (while pending), or "-"
+// (once complete — reviews expose no timestamps for FinalDuration).
 func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) string {
+	if check.Kind == "review" {
+		return m.renderCopilotReviewCheckRun(check, widths)
+	}
 	status := check.Status
 	conclusion := check.Conclusion
 
@@ -235,42 +249,14 @@ func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) 
 	return queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + styledAvg + "\n"
 }
 
-// renderCopilotStatusLine renders the Copilot review status under the PR
-// header: a spinner + elapsed line while pending, or a yellow stale warning
-// (issue #409).
-func (m Model) renderCopilotStatusLine() string {
-	if m.copilotPending && !m.copilotStale {
-		remaining := time.Until(m.copilotPollStartTime)
-		if remaining > 0 {
-			// Still inside the initial-delay window (copilotPollStartTime is
-			// set to PRInfoMsg-time + copilotInitialDelay). Polling hasn't
-			// started yet, so show a countdown rather than "0s elapsed".
-			return fmt.Sprintf("%s %s\n", m.spinner.View(),
-				m.styles.Running.Render(fmt.Sprintf("Copilot review queued, polling in %s…", timing.FormatDuration(remaining))))
-		}
-		elapsed := time.Since(m.copilotPollStartTime)
-		return fmt.Sprintf("%s %s\n", m.spinner.View(),
-			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))
-	}
-	if m.copilotStale {
-		shortHead := m.headSHA
-		if len(shortHead) > 7 {
-			shortHead = shortHead[:7]
-		}
-		return m.styles.Running.Render(
-			fmt.Sprintf("⚠ Copilot review is stale (HEAD is %s) — refresh or re-request\n", shortHead))
-	}
-	return ""
-}
+// renderCopilotReviewCheckRun renders a synthetic Copilot review row using
+// the same column geometry as renderCheckRun but with review-specific
+// icon, style, and blank queue/avg columns.
+func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) string {
+	icon := GetCopilotReviewIcon(check.ReviewState)
 
-// renderCopilotReviewRow renders the completed Copilot review as a row in the
-// check table with an icon by state, but no queue-latency or runtime columns
-// (reviews have no startedAt/completedAt — issue #409).
-func (m Model) renderCopilotReviewRow(widths ColumnWidths) string {
-	icon := GetCopilotReviewIcon(m.copilotState)
-
-	var style = m.styles.Queued
-	switch m.copilotState {
+	style := m.styles.Queued
+	switch check.ReviewState {
 	case "approved":
 		style = m.styles.Success
 	case "changes_requested":
@@ -279,25 +265,136 @@ func (m Model) renderCopilotReviewRow(widths ColumnWidths) string {
 		style = m.styles.Info
 	case "dismissed":
 		style = m.styles.Queued
+	case "pending", "stale":
+		style = m.styles.Running
 	}
 
-	// Pad the queue column with spaces (reviews have no queue latency) and
-	// render the name as "Copilot / <state>" to match the Workflow/Job format.
+	nameCol := BuildNameColumn(check, widths, false)
+
+	// Duration column: countdown while in the initial-delay window, elapsed
+	// runtime while in_progress (StartedAt was set to copilotPollStartTime
+	// by buildCopilotCheckRun so FormatDuration falls through to Runtime),
+	// or "-" once completed (timestamps are nil).
+	durationText := FormatDuration(check)
+	if check.Status == "queued" && !m.copilotPollStartTime.IsZero() {
+		remaining := time.Until(m.copilotPollStartTime)
+		if remaining > 0 {
+			durationText = "in " + timing.FormatDuration(remaining)
+		}
+	}
+
+	_, _, durationCol, _ := FormatAlignedColumns(
+		"", // queue column is blanked below
+		FormatCheckNameWithTruncate(check, widths.NameWidth),
+		durationText,
+		"", // avg column is blanked below
+		widths,
+	)
+	// Reviews carry no queue latency or historical average: blank both
+	// columns to keep the row aligned with the table geometry.
 	queueCol := strings.Repeat(" ", widths.QueueWidth)
-	nameCol := fmt.Sprintf("Copilot / %s", m.copilotState)
+	avgCol := strings.Repeat(" ", widths.AvgWidth)
 
-	// Apply same width-based truncation as check names
-	if runewidth.StringWidth(nameCol) > widths.NameWidth {
-		nameCol = runewidth.Truncate(nameCol, widths.NameWidth, "…")
+	styledIcon := style.Render(icon)
+	styledDuration := style.Render(durationCol)
+	styledName := style.Render(nameCol)
+
+	return queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + avgCol + "\n"
+}
+
+// buildCopilotCheckRun synthesizes a display-only CheckRunInfo representing
+// the current Copilot review state for the PR's HEAD commit. Returns nil
+// when no row should be rendered:
+//   - waitForCopilot disabled
+//   - review never armed (copilotWaitStartTime is zero)
+//   - not-requested with no stale review to surface
+//
+// The returned row never enters m.checkRuns; it is rendered separately as
+// the last row of the table and is excluded from SortCheckRuns,
+// allChecksComplete, and determineExitCode. Timing fields are populated
+// only to drive the duration-column display:
+//   - queued:   StartedAt/CompletedAt nil (FormatDuration falls to "-")
+//   - in_progress: StartedAt = copilotPollStartTime (Runtime yields elapsed)
+//   - completed: StartedAt/CompletedAt nil (FormatDuration returns "-")
+func (m Model) buildCopilotCheckRun() *ghclient.CheckRunInfo {
+	if !m.waitForCopilot {
+		return nil
 	}
-	namePadding := max(widths.NameWidth-runewidth.StringWidth(nameCol), 0)
-	paddedName := nameCol + strings.Repeat(" ", namePadding)
+	// Only render once the Copilot gate has been armed by PRInfoMsg.
+	if m.copilotWaitStartTime.IsZero() {
+		return nil
+	}
 
-	// No duration or avg columns — pad with spaces to align with the table
-	durPad := strings.Repeat(" ", widths.DurationWidth)
-	avgPad := strings.Repeat(" ", widths.AvgWidth)
+	const (
+		kind        = "review"
+		workflow    = "Copilot"
+		name        = "Review"
+		detailsURL  = ""
+	)
 
-	return queueCol + " " + style.Render(icon) + " " + style.Render(paddedName) + "  " + durPad + "  " + avgPad + "\n"
+	row := &ghclient.CheckRunInfo{
+		Kind:         kind,
+		WorkflowName: workflow,
+		Name:         name,
+		DetailsURL:   detailsURL,
+	}
+
+	switch {
+	case m.copilotStale:
+		row.Status = "completed"
+		row.ReviewState = "stale"
+	case m.copilotPending && !m.copilotReviewComplete:
+		// Pending: either still inside the initial-delay window (queued,
+		// countdown shown in duration column) or actively polling
+		// (in_progress, elapsed shown).
+		if !m.copilotPollStartTime.IsZero() && time.Until(m.copilotPollStartTime) > 0 {
+			row.Status = "queued"
+			row.ReviewState = "pending"
+		} else {
+			row.Status = "in_progress"
+			row.ReviewState = "pending"
+			start := m.copilotPollStartTime
+			row.StartedAt = &start
+		}
+	default:
+		// Review reached a terminal state (approved/commented/dismissed/
+		// changes_requested) or copilotReviewComplete was set with an empty
+		// copilotState (e.g. two-consecutive-not-requested). Suppress the
+		// row entirely if there's nothing to show.
+		if !m.copilotReviewComplete || m.copilotState == "" {
+			return nil
+		}
+		row.Status = "completed"
+		row.ReviewState = m.copilotState
+	}
+	return row
+}
+
+// widenForCopilotRow grows column widths to fit the synthetic Copilot row,
+// mirroring the per-column logic in CalculateColumnWidths but without
+// touching the queue column (which is blank for reviews) and capping the
+// name column at maxNameWidth. This keeps the header row and check rows
+// aligned when the Copilot row would otherwise exceed the geometry derived
+// from m.checkRuns alone.
+func widenForCopilotRow(widths ColumnWidths, row ghclient.CheckRunInfo) ColumnWidths {
+	const maxNameWidth = 60
+	name := FormatCheckName(row)
+	nameLen := runewidth.StringWidth(name)
+	if nameLen > widths.NameWidth {
+		if nameLen <= maxNameWidth {
+			widths.NameWidth = nameLen
+		} else {
+			widths.NameWidth = maxNameWidth
+		}
+	}
+	// Duration column may show "in 15s" style countdown text while queued,
+	// or the elapsed runtime while in_progress. Pre-compute both possible
+	// texts and widen to the larger of the two.
+	durationText := FormatDuration(row)
+	if runewidth.StringWidth(durationText) > widths.DurationWidth {
+		widths.DurationWidth = runewidth.StringWidth(durationText)
+	}
+	return widths
 }
 
 // renderStartupPhase shows helpful message during GitHub Actions startup delay

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -313,7 +313,7 @@ func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) 
 // the same column geometry as renderCheckRun but with review-specific
 // icon, style, and blank queue/avg columns.
 func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) string {
-	icon := GetCopilotReviewIcon(check.ReviewState)
+	icon := GetCopilotReviewIcon(check.ReviewState, check.Status)
 
 	style := m.styles.Queued
 	switch check.ReviewState {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -329,6 +329,12 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 		style = m.styles.Running
 	}
 
+	// enableLinks is hardcoded false here because buildCopilotCheckRun
+	// always sets DetailsURL: "" — there is no per-job URL for a synthetic
+	// review row, so a hyperlink would be a no-op even if m.enableLinks is
+	// set. (This is the only BuildNameColumn call site that doesn't pass
+	// m.enableLinks; keeping it explicit avoids a future reader wondering
+	// if it's a bug.)
 	nameCol := BuildNameColumn(check, widths, false)
 
 	// Duration column: countdown while in the initial-delay window, elapsed

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -76,7 +76,7 @@ func (m Model) View() tea.View {
 	// row when present, so the row never truncates its own name or the
 	// countdown/elapsed text in the duration column.
 	if copilotRow != nil {
-		widths = widenForCopilotRow(widths, *copilotRow)
+		widths = widenForCopilotRow(widths, *copilotRow, m.copilotPollStartTime)
 	}
 
 	headerQueue, headerName, headerDuration, headerAvg := FormatHeaderColumns(widths)
@@ -304,13 +304,11 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 	// or "-" once completed (timestamps are nil). Right-align to the
 	// column width, mirroring FormatAlignedColumns' duration padding
 	// without computing and discarding the queue/name/avg columns.
-	durationText := FormatDuration(check)
-	if check.Status == "queued" && !m.copilotPollStartTime.IsZero() {
-		remaining := time.Until(m.copilotPollStartTime)
-		if remaining > 0 {
-			durationText = "in " + timing.FormatDuration(remaining)
-		}
-	}
+	//
+	// copilotDurationText is shared with widenForCopilotRow so the width
+	// calc and the rendered row agree on the exact string — including the
+	// "in Xs" countdown that FormatDuration alone does not synthesize.
+	durationText := copilotDurationText(check, m.copilotPollStartTime)
 	durationPad := max(widths.DurationWidth-runewidth.StringWidth(durationText), 0)
 	durationCol := strings.Repeat(" ", durationPad) + durationText
 
@@ -435,27 +433,57 @@ func (m Model) buildCopilotCheckRun() *ghclient.CheckRunInfo {
 	return row
 }
 
+// copilotDurationText returns the string that renderCopilotReviewCheckRun
+// will display in the duration column for a synthetic Copilot review row:
+//
+//   - queued + inside the initial-delay window: "in <remaining>" countdown
+//     (e.g. "in 15s"), where remaining = time.Until(copilotPollStartTime)
+//   - queued + delay elapsed, or in_progress: the elapsed-runtime text
+//     FormatDuration derives from StartedAt (set to copilotPollStartTime
+//     by buildCopilotCheckRun), or "-" if StartedAt is nil
+//   - completed (or any other status): "-" — reviews expose no timestamps
+//     for FinalDuration
+//
+// widenForCopilotRow calls this same helper so the width calc and the
+// rendered row agree on the exact string, including the "in <remaining>"
+// countdown that FormatDuration(check) alone does not synthesize (it
+// returns "-" for queued rows). Without this shared path, a configured
+// copilot_initial_delay large enough to produce a wider countdown than
+// any other row's duration text (e.g. "in 1m 30s") would overflow the
+// pre-computed DurationWidth and misalign the Copilot row against the
+// header for the duration of the countdown.
+func copilotDurationText(check ghclient.CheckRunInfo, copilotPollStartTime time.Time) string {
+	if check.Status == "queued" && !copilotPollStartTime.IsZero() {
+		remaining := time.Until(copilotPollStartTime)
+		if remaining > 0 {
+			return "in " + timing.FormatDuration(remaining)
+		}
+	}
+	return FormatDuration(check)
+}
+
 // widenForCopilotRow grows column widths to fit the synthetic Copilot row,
 // mirroring the per-column logic in CalculateColumnWidths but without
 // touching the queue column (which is blank for reviews) and capping the
-// name column at maxNameWidth. This keeps the header row and check rows
+// name column at maxCheckNameWidth. This keeps the header row and check rows
 // aligned when the Copilot row would otherwise exceed the geometry derived
 // from m.checkRuns alone.
-func widenForCopilotRow(widths ColumnWidths, row ghclient.CheckRunInfo) ColumnWidths {
-	const maxNameWidth = 60
+func widenForCopilotRow(widths ColumnWidths, row ghclient.CheckRunInfo, copilotPollStartTime time.Time) ColumnWidths {
 	name := FormatCheckName(row)
 	nameLen := runewidth.StringWidth(name)
 	if nameLen > widths.NameWidth {
-		if nameLen <= maxNameWidth {
+		if nameLen <= maxCheckNameWidth {
 			widths.NameWidth = nameLen
 		} else {
-			widths.NameWidth = maxNameWidth
+			widths.NameWidth = maxCheckNameWidth
 		}
 	}
-	// Duration column may show "in 15s" style countdown text while queued,
-	// or the elapsed runtime while in_progress. Pre-compute both possible
-	// texts and widen to the larger of the two.
-	durationText := FormatDuration(row)
+	// Duration column may show "in 15s" style countdown text while queued
+	// (synthesized by copilotDurationText, NOT by FormatDuration which
+	// returns "-" for queued rows), or the elapsed runtime while
+	// in_progress. Use the shared helper so the width calc sees the same
+	// string the row will render, including the countdown prefix.
+	durationText := copilotDurationText(row, copilotPollStartTime)
 	if runewidth.StringWidth(durationText) > widths.DurationWidth {
 		widths.DurationWidth = runewidth.StringWidth(durationText)
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -54,17 +54,6 @@ func (m Model) View() tea.View {
 		fmt.Fprintf(&b, "%s %s\n", prInfo, utcTime)
 		fmt.Fprintf(&b, "%s\n", updatedLine)
 
-		// Copilot review status line (issue #409). Rendered above the
-		// check table so it is visible during the startup phase (when
-		// len(m.checkRuns) == 0 triggers an early return below) — Copilot
-		// polling is armed in PRInfoMsg independently of check discovery
-		// and typically resolves well before Actions checks appear.
-		// Suppressed once the review reaches a non-stale terminal state,
-		// since the table row below conveys that state on its own.
-		if m.waitForCopilot {
-			b.WriteString(m.renderCopilotStatusLine())
-		}
-
 		b.WriteString("\n")
 	}
 
@@ -118,6 +107,19 @@ func (m Model) View() tea.View {
 	// regardless of state, to keep its position predictable.
 	if copilotRow != nil {
 		b.WriteString(m.renderCheckRun(*copilotRow, widths))
+	}
+
+	// Copilot review status line (issue #409). Rendered below the Copilot
+	// table row, not in the header, so the spinner/countdown line sits
+	// visually next to the row it describes. Note: this call site is
+	// below the len(m.checkRuns)==0 early return above, so during the
+	// startup phase (before Actions checks appear) the status line is
+	// not rendered — Copilot polling is armed in PRInfoMsg independently
+	// of check discovery and typically resolves before checks appear.
+	// renderCopilotStatusLine self-gates via copilotWaitStartTime and
+	// returns "" for terminal non-stale states.
+	if m.waitForCopilot {
+		b.WriteString(m.renderCopilotStatusLine())
 	}
 
 	b.WriteString("\n")
@@ -324,17 +326,12 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 	return queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + avgCol + "\n"
 }
 
-// renderCopilotStatusLine renders the Copilot review status above the check
-// table: a spinner + countdown/elapsed line while pending, or a yellow stale
-// warning (issue #409). It is called from View() inside the PR-header block,
-// before the len(m.checkRuns)==0 early return, so it remains visible during
-// the startup phase when the table itself is suppressed — Copilot polling is
-// armed in PRInfoMsg independently of check discovery and typically resolves
-// well before Actions checks appear (30-90s after PR creation per CLAUDE.md).
-//
-// Returns "" when the review is in a non-stale terminal state (the table row
-// below conveys that state on its own, so the status line would be redundant)
-// or when the gate has not yet been armed.
+// renderCopilotStatusLine renders the Copilot review status below the
+// Copilot table row: a spinner + countdown/elapsed line while pending.
+// Returns "" when the review is in a terminal state (the table row
+// above conveys that state on its own, and stale-state guidance is
+// surfaced via the row's Summary line through renderSummary) or when
+// the gate has not yet been armed.
 func (m Model) renderCopilotStatusLine() string {
 	if m.copilotWaitStartTime.IsZero() {
 		return ""
@@ -351,10 +348,6 @@ func (m Model) renderCopilotStatusLine() string {
 		elapsed := time.Since(m.copilotPollStartTime)
 		return fmt.Sprintf("%s %s\n", m.spinner.View(),
 			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))
-	}
-	if m.copilotStale {
-		return m.styles.Running.Render(
-			fmt.Sprintf("⚠ Copilot review is stale (HEAD is %s) — refresh or re-request\n", shortHeadSHA(m.headSHA)))
 	}
 	return ""
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -89,7 +89,12 @@ func (m Model) View() tea.View {
 		checkLine := m.renderCheckRun(check, widths)
 		b.WriteString(checkLine)
 
-		if check.Summary != "" && (check.Conclusion == "failure" || check.Conclusion == "timed_out") {
+		// Render the summary line for failed checks, and for synthetic
+		// Copilot review rows that carry a Summary (e.g. the stale review
+		// guidance: "Copilot review is stale (HEAD is abc1234) — refresh
+		// or re-request"). Reviews have no Conclusion, so the Kind check
+		// is what gates them through.
+		if check.Summary != "" && ((check.Conclusion == "failure" || check.Conclusion == "timed_out") || check.Kind == "review") {
 			b.WriteString(m.renderSummary(check, widths))
 		}
 
@@ -398,6 +403,12 @@ func (m Model) buildCopilotCheckRun() *ghclient.CheckRunInfo {
 	case m.copilotStale:
 		row.Status = "completed"
 		row.ReviewState = "stale"
+		// Surface the stale-state guidance as a Summary line below the
+		// row (rendered via renderSummary). GetCopilotReviewIcon gives
+		// "stale" its own "⚠" icon, but the short SHA + actionable hint
+		// are too long for the name column, so they live here — this
+		// restores the information the pre-refactor status line carried.
+		row.Summary = fmt.Sprintf("Copilot review is stale (HEAD is %s) — refresh or re-request", shortHeadSHA(m.headSHA))
 	case m.copilotPending && !m.copilotReviewComplete:
 		// Pending: either still inside the initial-delay window (queued,
 		// countdown shown in duration column) or actively polling

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -74,10 +74,19 @@ func (m Model) View() tea.View {
 
 	widths := CalculateColumnWidths(m.checkRuns, m.headCommitTime, m.jobAverages)
 
+	// Compute the synthetic Copilot review row once and reuse it for both
+	// column-width widening and the row render. Calling buildCopilotCheckRun
+	// twice would take two time.Now() snapshots, and the queued/in_progress
+	// branch inside it (gated on time.Until(copilotPollStartTime)) could
+	// evaluate differently between the two calls if the countdown crosses
+	// zero mid-render — leading the widths calc and the rendered row to
+	// disagree on status.
+	copilotRow := m.buildCopilotCheckRun()
+
 	// Ensure the column geometry accommodates the synthetic Copilot review
 	// row when present, so the row never truncates its own name or the
 	// countdown/elapsed text in the duration column.
-	if copilotRow := m.buildCopilotCheckRun(); copilotRow != nil {
+	if copilotRow != nil {
 		widths = widenForCopilotRow(widths, *copilotRow)
 	}
 
@@ -107,7 +116,7 @@ func (m Model) View() tea.View {
 	// enters m.checkRuns, so allChecksComplete, SortCheckRuns, and
 	// determineExitCode are unaffected. It is always rendered last,
 	// regardless of state, to keep its position predictable.
-	if copilotRow := m.buildCopilotCheckRun(); copilotRow != nil {
+	if copilotRow != nil {
 		b.WriteString(m.renderCheckRun(*copilotRow, widths))
 	}
 
@@ -290,7 +299,9 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 	// Duration column: countdown while in the initial-delay window, elapsed
 	// runtime while in_progress (StartedAt was set to copilotPollStartTime
 	// by buildCopilotCheckRun so FormatDuration falls through to Runtime),
-	// or "-" once completed (timestamps are nil).
+	// or "-" once completed (timestamps are nil). Right-align to the
+	// column width, mirroring FormatAlignedColumns' duration padding
+	// without computing and discarding the queue/name/avg columns.
 	durationText := FormatDuration(check)
 	if check.Status == "queued" && !m.copilotPollStartTime.IsZero() {
 		remaining := time.Until(m.copilotPollStartTime)
@@ -298,14 +309,9 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 			durationText = "in " + timing.FormatDuration(remaining)
 		}
 	}
+	durationPad := max(widths.DurationWidth-runewidth.StringWidth(durationText), 0)
+	durationCol := strings.Repeat(" ", durationPad) + durationText
 
-	_, _, durationCol, _ := FormatAlignedColumns(
-		"", // queue column is blanked below
-		FormatCheckNameWithTruncate(check, widths.NameWidth),
-		durationText,
-		"", // avg column is blanked below
-		widths,
-	)
 	// Reviews carry no queue latency or historical average: blank both
 	// columns to keep the row aligned with the table geometry.
 	queueCol := strings.Repeat(" ", widths.QueueWidth)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -54,6 +54,17 @@ func (m Model) View() tea.View {
 		fmt.Fprintf(&b, "%s %s\n", prInfo, utcTime)
 		fmt.Fprintf(&b, "%s\n", updatedLine)
 
+		// Copilot review status line (issue #409). Rendered above the
+		// check table so it is visible during the startup phase (when
+		// len(m.checkRuns) == 0 triggers an early return below) — Copilot
+		// polling is armed in PRInfoMsg independently of check discovery
+		// and typically resolves well before Actions checks appear.
+		// Suppressed once the review reaches a non-stale terminal state,
+		// since the table row below conveys that state on its own.
+		if m.waitForCopilot {
+			b.WriteString(m.renderCopilotStatusLine())
+		}
+
 		b.WriteString("\n")
 	}
 
@@ -300,6 +311,50 @@ func (m Model) renderCopilotReviewCheckRun(check ghclient.CheckRunInfo, widths C
 	styledName := style.Render(nameCol)
 
 	return queueCol + " " + styledIcon + " " + styledName + "  " + styledDuration + "  " + avgCol + "\n"
+}
+
+// renderCopilotStatusLine renders the Copilot review status above the check
+// table: a spinner + countdown/elapsed line while pending, or a yellow stale
+// warning (issue #409). It is called from View() inside the PR-header block,
+// before the len(m.checkRuns)==0 early return, so it remains visible during
+// the startup phase when the table itself is suppressed — Copilot polling is
+// armed in PRInfoMsg independently of check discovery and typically resolves
+// well before Actions checks appear (30-90s after PR creation per CLAUDE.md).
+//
+// Returns "" when the review is in a non-stale terminal state (the table row
+// below conveys that state on its own, so the status line would be redundant)
+// or when the gate has not yet been armed.
+func (m Model) renderCopilotStatusLine() string {
+	if m.copilotWaitStartTime.IsZero() {
+		return ""
+	}
+	if m.copilotPending && !m.copilotStale {
+		remaining := time.Until(m.copilotPollStartTime)
+		if remaining > 0 {
+			// Still inside the initial-delay window (copilotPollStartTime
+			// is set to PRInfoMsg-time + copilotInitialDelay). Polling
+			// hasn't started yet, so show a countdown rather than "0s".
+			return fmt.Sprintf("%s %s\n", m.spinner.View(),
+				m.styles.Running.Render(fmt.Sprintf("Copilot review queued, polling in %s…", timing.FormatDuration(remaining))))
+		}
+		elapsed := time.Since(m.copilotPollStartTime)
+		return fmt.Sprintf("%s %s\n", m.spinner.View(),
+			m.styles.Running.Render(fmt.Sprintf("Copilot review in progress… (%s elapsed)", timing.FormatDuration(elapsed))))
+	}
+	if m.copilotStale {
+		return m.styles.Running.Render(
+			fmt.Sprintf("⚠ Copilot review is stale (HEAD is %s) — refresh or re-request\n", shortHeadSHA(m.headSHA)))
+	}
+	return ""
+}
+
+// shortHeadSHA returns the first 7 characters of a git SHA, matching GitHub's
+// short-SHA display convention. Returns "" when the SHA is empty.
+func shortHeadSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 // buildCopilotCheckRun synthesizes a display-only CheckRunInfo representing

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -326,10 +326,10 @@ func (m Model) buildCopilotCheckRun() *ghclient.CheckRunInfo {
 	}
 
 	const (
-		kind        = "review"
-		workflow    = "Copilot"
-		name        = "Review"
-		detailsURL  = ""
+		kind       = "review"
+		workflow   = "Copilot"
+		name       = "Review"
+		detailsURL = ""
 	)
 
 	row := &ghclient.CheckRunInfo{

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -94,14 +94,13 @@ func (m Model) View() tea.View {
 		checkLine := m.renderCheckRun(check, widths)
 		b.WriteString(checkLine)
 
-		// Render the summary line for failed checks, and for synthetic
-		// Copilot review rows that carry a Summary (e.g. the stale review
-		// guidance: "Copilot review is stale (HEAD is abc1234) — refresh
-		// or re-request"). Reviews have no Conclusion, so the Kind check
-		// is what gates them through.
-		if check.Summary != "" && ((check.Conclusion == "failure" || check.Conclusion == "timed_out") || check.Kind == "review") {
-			b.WriteString(m.renderSummary(check, widths))
-		}
+	// Render the summary line for failed checks. (Synthetic Copilot
+	// review rows never appear in m.checkRuns — they are rendered at the
+	// separate copilotRow site below — so the summary path for them is
+	// also reached there, not here.)
+	if check.Summary != "" && (check.Conclusion == "failure" || check.Conclusion == "timed_out") {
+		b.WriteString(m.renderSummary(check, widths))
+	}
 
 		if (check.Conclusion == "failure" || check.Conclusion == "timed_out") && len(check.Annotations) > 0 {
 			b.WriteString(m.renderErrorBox(check, widths))
@@ -114,6 +113,14 @@ func (m Model) View() tea.View {
 	// regardless of state, to keep its position predictable.
 	if copilotRow != nil {
 		b.WriteString(m.renderCheckRun(*copilotRow, widths))
+		// Surface the stale-review Summary below the synthetic row,
+		// mirroring the failed-check summary render inside the loop
+		// above. The stale case is the only Copilot state that sets
+		// Summary today, but gating on Summary != "" keeps this future-
+		// proof for other review states that may carry guidance.
+		if copilotRow.Summary != "" {
+			b.WriteString(m.renderSummary(*copilotRow, widths))
+		}
 	}
 
 	// Copilot review status line (issue #409). Rendered below the Copilot

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -35,11 +35,11 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 
 	t.Run("initial delay window: queued + pending", func(t *testing.T) {
 		m := &Model{
-			waitForCopilot:        true,
-			copilotPending:        true,
-			copilotWaitStartTime:  now,
-			copilotPollStartTime:  now.Add(15 * time.Second),
-			copilotInitialDelay:   15 * time.Second,
+			waitForCopilot:       true,
+			copilotPending:       true,
+			copilotWaitStartTime: now,
+			copilotPollStartTime: now.Add(15 * time.Second),
+			copilotInitialDelay:  15 * time.Second,
 		}
 		got := m.buildCopilotCheckRun()
 		if got == nil {
@@ -66,7 +66,7 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 		pollStart := now.Add(-30 * time.Second) // polling started 30s ago
 		m := &Model{
 			waitForCopilot:       true,
-			copilotPending:      true,
+			copilotPending:       true,
 			copilotWaitStartTime: now.Add(-45 * time.Second),
 			copilotPollStartTime: pollStart,
 		}
@@ -111,10 +111,10 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 
 	t.Run("approved review", func(t *testing.T) {
 		m := &Model{
-			waitForCopilot:         true,
-			copilotWaitStartTime:   now,
-			copilotReviewComplete:  true,
-			copilotState:           "approved",
+			waitForCopilot:        true,
+			copilotWaitStartTime:  now,
+			copilotReviewComplete: true,
+			copilotState:          "approved",
 		}
 		got := m.buildCopilotCheckRun()
 		if got == nil {
@@ -133,10 +133,10 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 
 	t.Run("changes_requested review", func(t *testing.T) {
 		m := &Model{
-			waitForCopilot:         true,
-			copilotWaitStartTime:   now,
-			copilotReviewComplete:  true,
-			copilotState:           "changes_requested",
+			waitForCopilot:        true,
+			copilotWaitStartTime:  now,
+			copilotReviewComplete: true,
+			copilotState:          "changes_requested",
 		}
 		got := m.buildCopilotCheckRun()
 		if got == nil {
@@ -149,10 +149,10 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 
 	t.Run("commented review", func(t *testing.T) {
 		m := &Model{
-			waitForCopilot:         true,
-			copilotWaitStartTime:   now,
-			copilotReviewComplete:  true,
-			copilotState:           "commented",
+			waitForCopilot:        true,
+			copilotWaitStartTime:  now,
+			copilotReviewComplete: true,
+			copilotState:          "commented",
 		}
 		got := m.buildCopilotCheckRun()
 		if got == nil {
@@ -165,10 +165,10 @@ func TestBuildCopilotCheckRun(t *testing.T) {
 
 	t.Run("dismissed review", func(t *testing.T) {
 		m := &Model{
-			waitForCopilot:         true,
-			copilotWaitStartTime:   now,
-			copilotReviewComplete:  true,
-			copilotState:           "dismissed",
+			waitForCopilot:        true,
+			copilotWaitStartTime:  now,
+			copilotReviewComplete: true,
+			copilotState:          "dismissed",
 		}
 		got := m.buildCopilotCheckRun()
 		if got == nil {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,0 +1,314 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	ghclient "github.com/fini-net/gh-observer/internal/github"
+)
+
+// stylesForTest returns a Styles instance suitable for render assertions.
+// Colors are not asserted on; the test only checks substrings and column
+// geometry, so any valid Styles value works.
+func stylesForTest() Styles {
+	return NewStyles(2, 1, 3, 8)
+}
+
+func TestBuildCopilotCheckRun(t *testing.T) {
+	now := time.Now()
+
+	t.Run("disabled returns nil", func(t *testing.T) {
+		m := &Model{waitForCopilot: false}
+		if got := m.buildCopilotCheckRun(); got != nil {
+			t.Errorf("expected nil when waitForCopilot disabled, got %+v", got)
+		}
+	})
+
+	t.Run("never armed returns nil", func(t *testing.T) {
+		m := &Model{waitForCopilot: true}
+		// copilotWaitStartTime zero
+		if got := m.buildCopilotCheckRun(); got != nil {
+			t.Errorf("expected nil when never armed, got %+v", got)
+		}
+	})
+
+	t.Run("initial delay window: queued + pending", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:        true,
+			copilotPending:        true,
+			copilotWaitStartTime:  now,
+			copilotPollStartTime:  now.Add(15 * time.Second),
+			copilotInitialDelay:   15 * time.Second,
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row during initial-delay window")
+		}
+		if got.Kind != "review" {
+			t.Errorf("Kind = %q, want \"review\"", got.Kind)
+		}
+		if got.Status != "queued" {
+			t.Errorf("Status = %q, want \"queued\"", got.Status)
+		}
+		if got.ReviewState != "pending" {
+			t.Errorf("ReviewState = %q, want \"pending\"", got.ReviewState)
+		}
+		if got.StartedAt != nil {
+			t.Errorf("StartedAt should be nil while queued, got %v", *got.StartedAt)
+		}
+		if got.WorkflowName != "Copilot" || got.Name != "Review" {
+			t.Errorf("name = %q / %q, want Copilot / Review", got.WorkflowName, got.Name)
+		}
+	})
+
+	t.Run("polling in progress: in_progress + StartedAt set", func(t *testing.T) {
+		pollStart := now.Add(-30 * time.Second) // polling started 30s ago
+		m := &Model{
+			waitForCopilot:       true,
+			copilotPending:      true,
+			copilotWaitStartTime: now.Add(-45 * time.Second),
+			copilotPollStartTime: pollStart,
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row while polling in progress")
+		}
+		if got.Status != "in_progress" {
+			t.Errorf("Status = %q, want \"in_progress\"", got.Status)
+		}
+		if got.ReviewState != "pending" {
+			t.Errorf("ReviewState = %q, want \"pending\"", got.ReviewState)
+		}
+		if got.StartedAt == nil {
+			t.Fatal("StartedAt should be set to copilotPollStartTime while in_progress")
+		}
+		if !got.StartedAt.Equal(pollStart) {
+			t.Errorf("StartedAt = %v, want %v", *got.StartedAt, pollStart)
+		}
+		if got.CompletedAt != nil {
+			t.Errorf("CompletedAt should remain nil while in_progress")
+		}
+	})
+
+	t.Run("stale review", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:       true,
+			copilotStale:         true,
+			copilotWaitStartTime: now,
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row for stale review")
+		}
+		if got.Status != "completed" {
+			t.Errorf("Status = %q, want \"completed\" for stale", got.Status)
+		}
+		if got.ReviewState != "stale" {
+			t.Errorf("ReviewState = %q, want \"stale\"", got.ReviewState)
+		}
+	})
+
+	t.Run("approved review", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:         true,
+			copilotWaitStartTime:   now,
+			copilotReviewComplete:  true,
+			copilotState:           "approved",
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row for approved review")
+		}
+		if got.Status != "completed" {
+			t.Errorf("Status = %q, want \"completed\"", got.Status)
+		}
+		if got.ReviewState != "approved" {
+			t.Errorf("ReviewState = %q, want \"approved\"", got.ReviewState)
+		}
+		if got.StartedAt != nil || got.CompletedAt != nil {
+			t.Errorf("timestamps should be nil for completed review")
+		}
+	})
+
+	t.Run("changes_requested review", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:         true,
+			copilotWaitStartTime:   now,
+			copilotReviewComplete:  true,
+			copilotState:           "changes_requested",
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row for changes_requested review")
+		}
+		if got.ReviewState != "changes_requested" {
+			t.Errorf("ReviewState = %q, want \"changes_requested\"", got.ReviewState)
+		}
+	})
+
+	t.Run("commented review", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:         true,
+			copilotWaitStartTime:   now,
+			copilotReviewComplete:  true,
+			copilotState:           "commented",
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row for commented review")
+		}
+		if got.ReviewState != "commented" {
+			t.Errorf("ReviewState = %q, want \"commented\"", got.ReviewState)
+		}
+	})
+
+	t.Run("dismissed review", func(t *testing.T) {
+		m := &Model{
+			waitForCopilot:         true,
+			copilotWaitStartTime:   now,
+			copilotReviewComplete:  true,
+			copilotState:           "dismissed",
+		}
+		got := m.buildCopilotCheckRun()
+		if got == nil {
+			t.Fatal("expected non-nil row for dismissed review")
+		}
+		if got.ReviewState != "dismissed" {
+			t.Errorf("ReviewState = %q, want \"dismissed\"", got.ReviewState)
+		}
+	})
+
+	t.Run("complete but empty state returns nil", func(t *testing.T) {
+		// Two-consecutive-not-requested path leaves copilotState empty even
+		// though copilotReviewComplete is true. No row should render.
+		m := &Model{
+			waitForCopilot:        true,
+			copilotWaitStartTime:  now,
+			copilotReviewComplete: true,
+			copilotState:          "",
+		}
+		if got := m.buildCopilotCheckRun(); got != nil {
+			t.Errorf("expected nil when state empty, got %+v", got)
+		}
+	})
+}
+
+func TestRenderCopilotReviewCheckRun(t *testing.T) {
+	widths := ColumnWidths{
+		QueueWidth:    5,
+		NameWidth:     20,
+		DurationWidth: 7,
+		AvgWidth:      7,
+	}
+	m := &Model{styles: stylesForTest()}
+
+	t.Run("approved row contains icon and name, blank queue and avg", func(t *testing.T) {
+		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "approved",
+		}, widths)
+		if !strings.Contains(row, "✓") {
+			t.Errorf("approved row missing ✓ icon: %q", row)
+		}
+		if !strings.Contains(row, "Copilot / Review") {
+			t.Errorf("approved row missing name: %q", row)
+		}
+		// Row should end with newline
+		if !strings.HasSuffix(row, "\n") {
+			t.Errorf("row should end with newline: %q", row)
+		}
+	})
+
+	t.Run("commented row uses chat-bubble icon", func(t *testing.T) {
+		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "commented",
+		}, widths)
+		if !strings.Contains(row, "💬") {
+			t.Errorf("commented row missing 💬 icon: %q", row)
+		}
+	})
+
+	t.Run("changes_requested row uses x icon", func(t *testing.T) {
+		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "changes_requested",
+		}, widths)
+		if !strings.Contains(row, "✗") {
+			t.Errorf("changes_requested row missing ✗ icon: %q", row)
+		}
+	})
+
+	t.Run("pending row uses in_progress icon", func(t *testing.T) {
+		start := time.Now().Add(-30 * time.Second)
+		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "in_progress",
+			ReviewState:  "pending",
+			StartedAt:    &start,
+		}, widths)
+		if !strings.Contains(row, "◐") {
+			t.Errorf("pending row missing ◐ icon: %q", row)
+		}
+	})
+
+	t.Run("stale row uses warning styling", func(t *testing.T) {
+		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "stale",
+		}, widths)
+		if !strings.Contains(row, "?") {
+			// stale has no specific icon in GetCopilotReviewIcon; falls to "?"
+			// which is acceptable — the style conveys the warning state.
+			t.Errorf("stale row missing icon: %q", row)
+		}
+	})
+}
+
+// TestRenderCheckRun_RegularRowUnchanged verifies that the Kind==""
+// fast path in renderCheckRun still renders regular check rows correctly
+// after the refactor introduced the review branch.
+func TestRenderCheckRun_RegularRowUnchanged(t *testing.T) {
+	m := &Model{styles: stylesForTest()}
+	startedAt := time.Now().Add(-5 * time.Minute)
+	completedAt := startedAt.Add(90 * time.Second)
+	check := ghclient.CheckRunInfo{
+		Name:         "build",
+		WorkflowName: "CI",
+		Status:       "completed",
+		Conclusion:   "success",
+		StartedAt:    &startedAt,
+		CompletedAt:  &completedAt,
+	}
+	widths := ColumnWidths{
+		QueueWidth:    5,
+		NameWidth:     20,
+		DurationWidth: 7,
+		AvgWidth:      7,
+	}
+	row := m.renderCheckRun(check, widths)
+	if !strings.Contains(row, "✓") {
+		t.Errorf("success row missing ✓ icon: %q", row)
+	}
+	if !strings.Contains(row, "CI / build") {
+		t.Errorf("row missing name: %q", row)
+	}
+	if !strings.Contains(row, "1m 30s") {
+		t.Errorf("row missing duration text: %q", row)
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -264,7 +264,7 @@ func TestRenderCopilotReviewCheckRun(t *testing.T) {
 		}
 	})
 
-	t.Run("stale row uses warning styling", func(t *testing.T) {
+	t.Run("stale row uses dedicated warning icon", func(t *testing.T) {
 		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
 			Kind:         "review",
 			WorkflowName: "Copilot",
@@ -272,12 +272,101 @@ func TestRenderCopilotReviewCheckRun(t *testing.T) {
 			Status:       "completed",
 			ReviewState:  "stale",
 		}, widths)
-		if !strings.Contains(row, "?") {
-			// stale has no specific icon in GetCopilotReviewIcon; falls to "?"
-			// which is acceptable — the style conveys the warning state.
-			t.Errorf("stale row missing icon: %q", row)
+		// "stale" has its own icon in GetCopilotReviewIcon (⚠), distinct
+		// from the generic "?" used for unrecognized states, so the user
+		// can tell a stale review apart from an unknown one by icon alone.
+		if !strings.Contains(row, "⚠") {
+			t.Errorf("stale row missing ⚠ icon: %q", row)
+		}
+		if strings.Contains(row, "?") {
+			t.Errorf("stale row should not fall through to generic '?' icon: %q", row)
 		}
 	})
+}
+
+// TestBuildCopilotCheckRun_StaleSummary verifies that the synthetic stale
+// review row carries a Summary line with the short SHA and actionable hint,
+// restoring the information the pre-refactor renderCopilotStatusLine carried.
+func TestBuildCopilotCheckRun_StaleSummary(t *testing.T) {
+	now := time.Now()
+	m := &Model{
+		waitForCopilot:       true,
+		copilotStale:         true,
+		copilotWaitStartTime: now,
+		headSHA:              "abcd1234ef567890",
+	}
+	got := m.buildCopilotCheckRun()
+	if got == nil {
+		t.Fatal("expected non-nil row for stale review")
+	}
+	if got.Summary == "" {
+		t.Fatal("expected non-empty Summary for stale review")
+	}
+	if !strings.Contains(got.Summary, "abcd123") {
+		t.Errorf("Summary should contain the 7-char short SHA, got %q", got.Summary)
+	}
+	if !strings.Contains(got.Summary, "refresh or re-request") {
+		t.Errorf("Summary should contain actionable hint, got %q", got.Summary)
+	}
+}
+
+// TestRenderCopilotStatusLine_StartupPhase verifies that the Copilot status
+// line is rendered during the startup phase (when len(m.checkRuns) == 0 and
+// the table itself is suppressed). This guards the regression introduced by
+// the original refactor where the Copilot row moved below the early return.
+func TestRenderCopilotStatusLine_StartupPhase(t *testing.T) {
+	m := &Model{
+		styles:               stylesForTest(),
+		waitForCopilot:       true,
+		copilotPending:       true,
+		copilotWaitStartTime: time.Now(),
+		copilotPollStartTime: time.Now().Add(15 * time.Second),
+	}
+	line := m.renderCopilotStatusLine()
+	if line == "" {
+		t.Fatal("expected non-empty status line while pending during startup phase")
+	}
+	if !strings.Contains(line, "Copilot review queued, polling in") {
+		t.Errorf("status line should show countdown while in initial-delay window, got %q", line)
+	}
+}
+
+// TestRenderCopilotStatusLine_Stale verifies that the stale warning carries
+// the short SHA and actionable hint, matching the pre-refactor behavior.
+func TestRenderCopilotStatusLine_Stale(t *testing.T) {
+	m := &Model{
+		styles:               stylesForTest(),
+		waitForCopilot:       true,
+		copilotStale:         true,
+		copilotWaitStartTime: time.Now(),
+		headSHA:              "abcd1234ef567890",
+	}
+	line := m.renderCopilotStatusLine()
+	if !strings.Contains(line, "⚠") {
+		t.Errorf("stale status line should start with ⚠, got %q", line)
+	}
+	if !strings.Contains(line, "abcd123") {
+		t.Errorf("stale status line should contain short SHA, got %q", line)
+	}
+	if !strings.Contains(line, "refresh or re-request") {
+		t.Errorf("stale status line should contain actionable hint, got %q", line)
+	}
+}
+
+// TestRenderCopilotStatusLine_CompletedReturnsEmpty verifies that the status
+// line is suppressed once the review reaches a non-stale terminal state, so
+// the table row is the sole presenter of that state (no double-printing).
+func TestRenderCopilotStatusLine_CompletedReturnsEmpty(t *testing.T) {
+	m := &Model{
+		styles:                stylesForTest(),
+		waitForCopilot:        true,
+		copilotWaitStartTime:  time.Now(),
+		copilotReviewComplete: true,
+		copilotState:          "approved",
+	}
+	if got := m.renderCopilotStatusLine(); got != "" {
+		t.Errorf("status line should be empty for non-stale terminal state, got %q", got)
+	}
 }
 
 // TestRenderCheckRun_RegularRowUnchanged verifies that the Kind==""

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -546,18 +546,18 @@ func TestView_StaleCopilotSummaryRendered(t *testing.T) {
 	}}
 
 	m := &Model{
-		styles:                stylesForTest(),
-		prTitle:               "Test PR",
-		prNumber:              1,
-		headSHA:               "abcd1234ef567890",
-		checkRuns:             checks,
-		lastUpdate:            time.Now(),
-		startTime:             time.Now().Add(-10 * time.Minute),
-		waitForCopilot:        true,
-		copilotStale:          true,
-		copilotWaitStartTime:  time.Now(),
-		fetchReceived:         true,
-		rateLimitRemaining:    5000,
+		styles:               stylesForTest(),
+		prTitle:              "Test PR",
+		prNumber:             1,
+		headSHA:              "abcd1234ef567890",
+		checkRuns:            checks,
+		lastUpdate:           time.Now(),
+		startTime:            time.Now().Add(-10 * time.Minute),
+		waitForCopilot:       true,
+		copilotStale:         true,
+		copilotWaitStartTime: time.Now(),
+		fetchReceived:        true,
+		rateLimitRemaining:   5000,
 	}
 
 	out := m.View().Content
@@ -581,7 +581,7 @@ func TestView_StaleCopilotSummaryRendered(t *testing.T) {
 // countdown's display width.
 func TestRenderCopilotReviewCheckRun_LongCountdown(t *testing.T) {
 	m := &Model{
-		styles:             stylesForTest(),
+		styles:               stylesForTest(),
 		copilotPollStartTime: time.Now().Add(90 * time.Second), // remaining ≈ 1m 30s
 	}
 	row := ghclient.CheckRunInfo{

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -398,3 +398,159 @@ func TestRenderCheckRun_RegularRowUnchanged(t *testing.T) {
 		t.Errorf("row missing duration text: %q", row)
 	}
 }
+
+// TestWidenForCopilotRow verifies that widenForCopilotRow grows the
+// duration and name columns to fit the synthetic Copilot row, including
+// the "in <remaining>" countdown text that FormatDuration alone does not
+// synthesize for queued rows. This locks in the fix for the
+// column-misalignment regression where the countdown could overflow the
+// pre-computed DurationWidth derived from FormatDuration("-").
+func TestWidenForCopilotRow(t *testing.T) {
+	t.Run("countdown text widens DurationWidth past FormatDuration dash", func(t *testing.T) {
+		// Queued row inside the initial-delay window: copilotDurationText
+		// returns "in 1m 30s" (9 cells), but FormatDuration would return
+		// "-" (1 cell). The widths must accommodate the countdown, not the
+		// dash, or the rendered row will overflow the column.
+		widths := ColumnWidths{
+			QueueWidth:    5,
+			NameWidth:     20,
+			DurationWidth: 5, // minTimeWidth; smaller than "in 1m 30s"
+			AvgWidth:      5,
+		}
+		row := ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "queued",
+			ReviewState:  "pending",
+		}
+		pollStart := time.Now().Add(90 * time.Second) // remaining ≈ 1m 30s
+
+		got := widenForCopilotRow(widths, row, pollStart)
+		if got.DurationWidth <= widths.DurationWidth {
+			t.Errorf("DurationWidth should grow to fit countdown, got %d (was %d); countdown is 9 cells",
+				got.DurationWidth, widths.DurationWidth)
+		}
+		if got.DurationWidth < 9 {
+			t.Errorf("DurationWidth should be >= 9 for \"in 1m 30s\", got %d", got.DurationWidth)
+		}
+	})
+
+	t.Run("completed row does not grow DurationWidth beyond dash", func(t *testing.T) {
+		// Completed rows have no timestamps; copilotDurationText returns
+		// "-" (1 cell), which never exceeds minTimeWidth. No growth expected.
+		widths := ColumnWidths{
+			QueueWidth:    5,
+			NameWidth:     20,
+			DurationWidth: 7,
+			AvgWidth:      5,
+		}
+		row := ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "approved",
+		}
+		got := widenForCopilotRow(widths, row, time.Now().Add(15*time.Second))
+		if got.DurationWidth != widths.DurationWidth {
+			t.Errorf("DurationWidth should not change for completed row, got %d (was %d)",
+				got.DurationWidth, widths.DurationWidth)
+		}
+	})
+
+	t.Run("name column grows up to maxCheckNameWidth cap", func(t *testing.T) {
+		widths := ColumnWidths{
+			QueueWidth:    5,
+			NameWidth:     10, // smaller than "Copilot / Review" (16)
+			DurationWidth: 7,
+			AvgWidth:      5,
+		}
+		// Name "Copilot / Review" is 16 cells, under the cap — should grow NameWidth to 16.
+		row := ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "completed",
+			ReviewState:  "approved",
+		}
+		got := widenForCopilotRow(widths, row, time.Now())
+		if got.NameWidth != 16 {
+			t.Errorf("NameWidth should be 16 for \"Copilot / Review\", got %d", got.NameWidth)
+		}
+	})
+
+	t.Run("name column caps at maxCheckNameWidth for very long names", func(t *testing.T) {
+		widths := ColumnWidths{
+			QueueWidth:    5,
+			NameWidth:     20,
+			DurationWidth: 7,
+			AvgWidth:      5,
+		}
+		longName := strings.Repeat("a", maxCheckNameWidth+50)
+		row := ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         longName,
+			Status:       "completed",
+			ReviewState:  "approved",
+		}
+		got := widenForCopilotRow(widths, row, time.Now())
+		if got.NameWidth != maxCheckNameWidth {
+			t.Errorf("NameWidth should cap at %d, got %d", maxCheckNameWidth, got.NameWidth)
+		}
+	})
+
+	t.Run("no-op when widths already accommodate the row", func(t *testing.T) {
+		widths := ColumnWidths{
+			QueueWidth:    5,
+			NameWidth:     60,
+			DurationWidth: 20,
+			AvgWidth:      5,
+		}
+		row := ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "queued",
+			ReviewState:  "pending",
+		}
+		pollStart := time.Now().Add(15 * time.Second)
+		got := widenForCopilotRow(widths, row, pollStart)
+		if got.NameWidth != widths.NameWidth || got.DurationWidth != widths.DurationWidth {
+			t.Errorf("widths should be unchanged when already large enough, got %+v (was %+v)", got, widths)
+		}
+	})
+}
+
+// TestRenderCopilotReviewCheckRun_LongCountdown verifies that a long
+// initial-delay countdown ("in 1m 30s") is rendered without truncation
+// and right-aligns to the column width, locking in the
+// copilotDurationText/widenForCopilotRow agreement. The row is fed the
+// same copilotPollStartTime the width calc would use, and the test
+// asserts the countdown appears verbatim and the column matches the
+// countdown's display width.
+func TestRenderCopilotReviewCheckRun_LongCountdown(t *testing.T) {
+	m := &Model{
+		styles:             stylesForTest(),
+		copilotPollStartTime: time.Now().Add(90 * time.Second), // remaining ≈ 1m 30s
+	}
+	row := ghclient.CheckRunInfo{
+		Kind:         "review",
+		WorkflowName: "Copilot",
+		Name:         "Review",
+		Status:       "queued",
+		ReviewState:  "pending",
+	}
+	widths := widenForCopilotRow(ColumnWidths{
+		QueueWidth:    5,
+		NameWidth:     20,
+		DurationWidth: 5,
+		AvgWidth:      5,
+	}, row, m.copilotPollStartTime)
+
+	rendered := m.renderCopilotReviewCheckRun(row, widths)
+	if !strings.Contains(rendered, "in 1m 30s") {
+		t.Errorf("row should contain the countdown text verbatim, got %q", rendered)
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -264,6 +264,33 @@ func TestRenderCopilotReviewCheckRun(t *testing.T) {
 		}
 	})
 
+	t.Run("queued pending row uses pause icon, not in_progress spinner", func(t *testing.T) {
+		// While still inside copilotInitialDelay the duration column shows
+		// "in 15s" and Status is "queued". The icon must be ⏸ (pause) to
+		// match that countdown — showing the in_progress spinner ◐ while
+		// the row says "in 15s" would be mixed signals.
+		m2 := &Model{
+			styles:               stylesForTest(),
+			copilotPollStartTime: time.Now().Add(15 * time.Second),
+		}
+		row := m2.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
+			Kind:         "review",
+			WorkflowName: "Copilot",
+			Name:         "Review",
+			Status:       "queued",
+			ReviewState:  "pending",
+		}, widths)
+		if !strings.Contains(row, "⏸") {
+			t.Errorf("queued pending row missing ⏸ icon: %q", row)
+		}
+		if strings.Contains(row, "◐") {
+			t.Errorf("queued pending row should not show in_progress spinner ◐: %q", row)
+		}
+		if !strings.Contains(row, "in 15s") {
+			t.Errorf("queued pending row missing countdown text: %q", row)
+		}
+	})
+
 	t.Run("stale row uses dedicated warning icon", func(t *testing.T) {
 		row := m.renderCopilotReviewCheckRun(ghclient.CheckRunInfo{
 			Kind:         "review",

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -310,11 +310,13 @@ func TestBuildCopilotCheckRun_StaleSummary(t *testing.T) {
 	}
 }
 
-// TestRenderCopilotStatusLine_StartupPhase verifies that the Copilot status
-// line is rendered during the startup phase (when len(m.checkRuns) == 0 and
-// the table itself is suppressed). This guards the regression introduced by
-// the original refactor where the Copilot row moved below the early return.
-func TestRenderCopilotStatusLine_StartupPhase(t *testing.T) {
+// TestRenderCopilotStatusLine_PendingCountdown verifies that the status line
+// shows a countdown while inside the initial-delay window. The function is
+// called directly here; in View() it is now invoked below the Copilot table
+// row rather than in the header block (Option B), so it is no longer shown
+// during the startup phase when len(m.checkRuns) == 0 triggers an early
+// return before the call site — see the comment in View() for the tradeoff.
+func TestRenderCopilotStatusLine_PendingCountdown(t *testing.T) {
 	m := &Model{
 		styles:               stylesForTest(),
 		waitForCopilot:       true,
@@ -324,16 +326,18 @@ func TestRenderCopilotStatusLine_StartupPhase(t *testing.T) {
 	}
 	line := m.renderCopilotStatusLine()
 	if line == "" {
-		t.Fatal("expected non-empty status line while pending during startup phase")
+		t.Fatal("expected non-empty status line while pending in initial-delay window")
 	}
 	if !strings.Contains(line, "Copilot review queued, polling in") {
 		t.Errorf("status line should show countdown while in initial-delay window, got %q", line)
 	}
 }
 
-// TestRenderCopilotStatusLine_Stale verifies that the stale warning carries
-// the short SHA and actionable hint, matching the pre-refactor behavior.
-func TestRenderCopilotStatusLine_Stale(t *testing.T) {
+// TestRenderCopilotStatusLine_StaleReturnsEmpty verifies that the status line
+// is suppressed when the review is stale. Stale-state guidance is surfaced
+// solely by the synthetic Copilot row's Summary line via renderSummary, so
+// the status line returns "" to avoid double-printing (issue #409).
+func TestRenderCopilotStatusLine_StaleReturnsEmpty(t *testing.T) {
 	m := &Model{
 		styles:               stylesForTest(),
 		waitForCopilot:       true,
@@ -341,15 +345,8 @@ func TestRenderCopilotStatusLine_Stale(t *testing.T) {
 		copilotWaitStartTime: time.Now(),
 		headSHA:              "abcd1234ef567890",
 	}
-	line := m.renderCopilotStatusLine()
-	if !strings.Contains(line, "⚠") {
-		t.Errorf("stale status line should start with ⚠, got %q", line)
-	}
-	if !strings.Contains(line, "abcd123") {
-		t.Errorf("stale status line should contain short SHA, got %q", line)
-	}
-	if !strings.Contains(line, "refresh or re-request") {
-		t.Errorf("stale status line should contain actionable hint, got %q", line)
+	if got := m.renderCopilotStatusLine(); got != "" {
+		t.Errorf("stale status line should be empty (Summary carries it), got %q", got)
 	}
 }
 

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -523,6 +523,55 @@ func TestWidenForCopilotRow(t *testing.T) {
 	})
 }
 
+// TestView_StaleCopilotSummaryRendered verifies end-to-end that a stale
+// Copilot review surfaces its Summary line in the rendered View output.
+// buildCopilotCheckRun sets row.Summary for the stale case, but the row
+// is rendered outside the m.checkRuns loop (which previously made the
+// in-loop `check.Kind == "review"` branch unreachable dead code). This
+// test guards against regressing the separate renderSummary call at the
+// copilotRow render site — without it, only the ⚠ icon shows and the
+// "HEAD is <sha> — refresh or re-request" guidance is lost.
+func TestView_StaleCopilotSummaryRendered(t *testing.T) {
+	startedAt := time.Now().Add(-5 * time.Minute)
+	completedAt := startedAt.Add(60 * time.Second)
+	startedPtr := &startedAt
+	completedPtr := &completedAt
+	checks := []ghclient.CheckRunInfo{{
+		Name:         "build",
+		WorkflowName: "CI",
+		Status:       "completed",
+		Conclusion:   "success",
+		StartedAt:    startedPtr,
+		CompletedAt:  completedPtr,
+	}}
+
+	m := &Model{
+		styles:                stylesForTest(),
+		prTitle:               "Test PR",
+		prNumber:              1,
+		headSHA:               "abcd1234ef567890",
+		checkRuns:             checks,
+		lastUpdate:            time.Now(),
+		startTime:             time.Now().Add(-10 * time.Minute),
+		waitForCopilot:        true,
+		copilotStale:          true,
+		copilotWaitStartTime:  time.Now(),
+		fetchReceived:         true,
+		rateLimitRemaining:    5000,
+	}
+
+	out := m.View().Content
+	if !strings.Contains(out, "Copilot review is stale") {
+		t.Errorf("View output should contain the stale-review Summary line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "abcd123") {
+		t.Errorf("View output should contain the short SHA in the stale summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "refresh or re-request") {
+		t.Errorf("View output should contain the actionable hint, got:\n%s", out)
+	}
+}
+
 // TestRenderCopilotReviewCheckRun_LongCountdown verifies that a long
 // initial-delay countdown ("in 1m 30s") is rendered without truncation
 // and right-aligns to the column width, locking in the


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🛬 [src] copilot reviews are displayed like other github actions running
- 🎨 [src] gofmt the copilot review row refactor
- 🛟 [src] show copilot status line during startup phase
- ⚠ [src] give stale copilot reviews a dedicated icon and summary
- 🧹 [src] dedup buildCopilotCheckRun and drop wasted column call
- 📍 [src] move copilot status line from header to the copilot row
- 🐛 [src] widen copilot row for the countdown text it actually renders
- 📝 [src] clarify startup-phase copilot visibility tradeoff in comments
- 🧪 [src] cover widenForCopilotRow and the long-countdown render path
- 🐛 [src] render stale copilot review summary at the copilotRow call site
- 🎨 [src] gofmt the copilot review row loop body and test literals
- 🧹 [src] hoist copilot "review" Kind literal to shared constant
- ⚠ [src] give queued copilot rows a pause icon instead of the spinner
- 📝 [src] document why enableLinks is false for copilot review rows

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
