### PR TITLE
🤛 [src] use push time instead of commit time, fixes #349

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ gh-observer follows a clean architecture with distinct layers:
 **Input type** (from `parseArgs()`):
 
 - **PR mode** - Watches checks on a PR; accepts PR number, PR URL, or auto-detects from current branch
-- **Run mode** - Watches jobs in a standalone Actions run URL. No queue latency column (run-mode rows have no commit push event to reference). The "Pushed Xs ago" header uses `RunInfo.HeadPushedTime`, sourced from a GraphQL `Repository.commit(oid:)` `pushedDate` lookup (with `committedDate` and REST `head_commit.timestamp` fallbacks) — see issue #349.
+- **Run mode** - Watches jobs in a standalone Actions run URL. No queue latency column (run-mode rows have no commit push event to reference). The "Pushed Xs ago" header uses `RunInfo.HeadPushedTime`, sourced from a GraphQL `Repository.object(oid:) ... on Commit` `pushedDate` lookup (with `committedDate` and REST `head_commit.timestamp` fallbacks) — see issue #349.
 
 **Output type** (from `term.IsTerminal(os.Stdout.Fd())`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ gh-observer follows a clean architecture with distinct layers:
 **Input type** (from `parseArgs()`):
 
 - **PR mode** - Watches checks on a PR; accepts PR number, PR URL, or auto-detects from current branch
-- **Run mode** - Watches jobs in a standalone Actions run URL. No queue latency column (no commit push event to reference)
+- **Run mode** - Watches jobs in a standalone Actions run URL. No queue latency column (run-mode rows have no commit push event to reference). The "Pushed Xs ago" header uses `RunInfo.HeadPushedTime`, sourced from a GraphQL `Repository.commit(oid:)` `pushedDate` lookup (with `committedDate` and REST `head_commit.timestamp` fallbacks) — see issue #349.
 
 **Output type** (from `term.IsTerminal(os.Stdout.Fd())`):
 
@@ -93,7 +93,7 @@ Check names display as "Workflow Name / Job Name". Failed checks include inline 
 
 ### Key timing calculations (`internal/timing/calculator.go`)
 
-- **Queue latency**: `check.StartedAt - headCommitTime` (how long GitHub took to queue)
+- **Queue latency**: `check.StartedAt - headPushedTime` (how long GitHub took to queue after the push). `headPushedTime` is the head commit's `pushedDate` (with `committedDate` fallback) sourced from GraphQL; the Actions REST API exposes only the committer timestamp, not the push time.
 - **Runtime**: `time.Now() - check.StartedAt` (in_progress only)
 - **Final duration**: `check.CompletedAt - check.StartedAt`
 

--- a/docs/linear-walkthrough.md
+++ b/docs/linear-walkthrough.md
@@ -409,7 +409,7 @@ if check.Status == "completed" {
 Mirrors the PR snapshot but for a standalone workflow run:
 
 ```go
-runInfo, err := ghclient.FetchRunInfo(ctx, client, owner, repo, runID)
+runInfo, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
 jobs, _, err := ghclient.FetchRunJobs(ctx, client, owner, repo, runID)
 
 // Header: pushed/created time, display title

--- a/docs/linear-walkthrough.md
+++ b/docs/linear-walkthrough.md
@@ -325,15 +325,17 @@ Snapshot mode runs when stdout is not a terminal (e.g., scripts, CI, redirected 
 ```go
 client, err := ghclient.NewClient(ctx)
 prInfo, err := ghclient.FetchPRInfo(ctx, client, owner, repo, prNumber)
-headCommitTime, err := time.Parse(time.RFC3339, prInfo.HeadCommitDate)
 ```
 
-Uses REST API to get PR title, head SHA, and timestamps.
+Uses REST API to get PR title, head SHA, and created-at timestamp. The head
+commit's push time is sourced separately from the GraphQL check-runs query
+(`FetchCheckRunsGraphQL`), which fetches `pushedDate` in the same round-trip
+as the StatusCheckRollup (issue #349).
 
 #### Step 2: Fetch Check Runs
 
 ```go
-checkRuns, _, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
+checkRuns, headPushedTime, _, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
 ```
 
 Returns `[]CheckRunInfo` with workflow names, status, timestamps, and annotations.
@@ -899,14 +901,12 @@ Uses REST API for PR info and commit timestamps:
 ```go
 func FetchPRInfo(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (*PRInfo, error) {
     pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)
-    commit, _, err := client.Repositories.GetCommit(ctx, owner, repo, headSHA, nil)
     
     return &PRInfo{
-        Number:         prNumber,
-        Title:          pr.GetTitle(),
-        HeadSHA:        headSHA,
-        CreatedAt:      pr.GetCreatedAt().Format(TimestampFormat),
-        HeadCommitDate: commit.GetCommit().GetCommitter().GetDate().Format(TimestampFormat),
+        Number:    prNumber,
+        Title:     pr.GetTitle(),
+        HeadSHA:   headSHA,
+        CreatedAt: pr.GetCreatedAt().Format(TimestampFormat),
     }, nil
 }
 ```
@@ -1342,10 +1342,10 @@ main.go run()
         │   └── Creates REST API client with OAuth2
         │
         ├── ghclient.FetchPRInfo()                      [internal/github/pr.go]
-        │   └── Returns: PRInfo{Title, HeadSHA, HeadCommitDate}
+        │   └── Returns: PRInfo{Title, HeadSHA, CreatedAt}
         │
         ├── ghclient.FetchCheckRunsGraphQL()            [internal/github/graphql.go]
-        │   └── Returns: []CheckRunInfo{Name, WorkflowName, AppName, Status, ...}
+        │   └── Returns: []CheckRunInfo{...}, headPushedTime, rateLimit
         │
         ├── ghclient.FetchJobAverages() (unless --quick)
         │   └── Returns: map[jobName]averageDuration

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -120,6 +120,8 @@ type pullRequestQuery struct {
 			Commits struct {
 				Nodes []struct {
 					Commit struct {
+						PushedDate        githubv4.DateTime `graphql:"pushedDate"`
+						CommittedDate     githubv4.DateTime `graphql:"committedDate"`
 						StatusCheckRollup struct {
 							Contexts struct {
 								Nodes    []contextNode
@@ -230,21 +232,28 @@ func contextNodesToCheckRuns(nodes []contextNode) []CheckRunInfo {
 
 // FetchCheckRunsGraphQL fetches check runs with workflow names using GraphQL
 // with cursor-based pagination to handle PRs with more than 100 status contexts.
-func FetchCheckRunsGraphQL(ctx context.Context, token, owner, repo string, prNumber int) ([]CheckRunInfo, int, error) {
+// Also returns the head commit's push time (pushedDate, falling back to
+// committedDate when pushedDate is absent) so callers can render queue
+// latency and "Pushed Xs ago" against the push time rather than the
+// (possibly stale) commit time. The push time is populated from the first
+// page only; if the PR has no commits or the first page errors, the zero
+// value is returned and callers must fall back.
+func FetchCheckRunsGraphQL(ctx context.Context, token, owner, repo string, prNumber int) ([]CheckRunInfo, time.Time, int, error) {
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(ctx, src)
 	client := githubv4.NewClient(httpClient)
 	return fetchCheckRunsGraphQL(ctx, client, owner, repo, prNumber)
 }
 
-func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, repo string, prNumber int) ([]CheckRunInfo, int, error) {
+func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, repo string, prNumber int) ([]CheckRunInfo, time.Time, int, error) {
 	var allCheckRuns []CheckRunInfo
+	var headPushedTime time.Time
 	var cursor *githubv4.String
 	rateLimitRemaining := 5000
 
 	prNum, err := safeGraphQLInt(prNumber)
 	if err != nil {
-		return nil, rateLimitRemaining, err
+		return nil, headPushedTime, rateLimitRemaining, err
 	}
 
 	for {
@@ -263,7 +272,7 @@ func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, re
 		err := client.Query(ctx, &query, variables)
 		if err != nil {
 			debug.Log("graphql query failed", "owner", owner, "repo", repo, "pr", prNumber, "err", err)
-			return nil, rateLimitRemaining, err
+			return nil, headPushedTime, rateLimitRemaining, err
 		}
 
 		debug.Log("graphql query success", "owner", owner, "repo", repo, "pr", prNumber, "rate_limit_remaining", query.RateLimit.Remaining)
@@ -277,6 +286,16 @@ func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, re
 		}
 
 		commit := query.Repository.PullRequest.Commits.Nodes[0]
+		// Capture push time from the first page; subsequent pages operate
+		// on the same commit and would just overwrite with the same value.
+		if headPushedTime.IsZero() {
+			if !commit.Commit.PushedDate.IsZero() {
+				headPushedTime = commit.Commit.PushedDate.Time
+			} else if !commit.Commit.CommittedDate.IsZero() {
+				headPushedTime = commit.Commit.CommittedDate.Time
+			}
+		}
+
 		contexts := commit.Commit.StatusCheckRollup.Contexts
 		allCheckRuns = append(allCheckRuns, contextNodesToCheckRuns(contexts.Nodes)...)
 
@@ -286,5 +305,5 @@ func fetchCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner, re
 		cursor = &contexts.PageInfo.EndCursor
 	}
 
-	return allCheckRuns, rateLimitRemaining, nil
+	return allCheckRuns, headPushedTime, rateLimitRemaining, nil
 }

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -10,24 +10,24 @@ import (
 )
 
 type checkRunContextFields struct {
-	Name          string
-	Summary       string
-	Status        string
-	Conclusion    string
-	StartedAt     githubv4.DateTime
-	CompletedAt   githubv4.DateTime
-	DetailsURL    string
-	Annotations   []struct {
+	Name        string
+	Summary     string
+	Status      string
+	Conclusion  string
+	StartedAt   githubv4.DateTime
+	CompletedAt githubv4.DateTime
+	DetailsURL  string
+	Annotations []struct {
 		Message         string
 		Path            string
 		Title           string
 		AnnotationLevel string
 		StartLine       int
 	}
-	WorkflowName   string
-	AppName        string
-	WorkflowRunID  int64
-	WorkflowID     int64
+	WorkflowName  string
+	AppName       string
+	WorkflowRunID int64
+	WorkflowID    int64
 }
 
 func makeCheckRunNode(f checkRunContextFields) contextNode {
@@ -308,10 +308,10 @@ func TestContextNodesToCheckRuns(t *testing.T) {
 			name: "GHAS check with AppName but no WorkflowName",
 			nodes: []contextNode{
 				makeCheckRunNode(checkRunContextFields{
-					Name:        "analyze",
-					Status:      "COMPLETED",
-					Conclusion:  "SUCCESS",
-					AppName:     "GitHub Code Scanning",
+					Name:       "analyze",
+					Status:     "COMPLETED",
+					Conclusion: "SUCCESS",
+					AppName:    "GitHub Code Scanning",
 				}),
 			},
 			wantLen:          1,
@@ -331,11 +331,11 @@ func TestContextNodesToCheckRuns(t *testing.T) {
 					WorkflowID:    456,
 				}),
 			},
-			wantLen:            1,
-			wantName:           []string{"test"},
-			wantWorkflowName:   []string{"CI"},
-			wantWorkflowRunID:  []int64{123},
-			wantWorkflowID:     []int64{456},
+			wantLen:           1,
+			wantName:          []string{"test"},
+			wantWorkflowName:  []string{"CI"},
+			wantWorkflowRunID: []int64{123},
+			wantWorkflowID:    []int64{456},
 		},
 		{
 			name: "CheckRun with large workflow IDs exceeding int32",
@@ -349,11 +349,11 @@ func TestContextNodesToCheckRuns(t *testing.T) {
 					WorkflowID:    9876543210,
 				}),
 			},
-			wantLen:            1,
-			wantName:           []string{"test"},
-			wantWorkflowName:   []string{"CI"},
-			wantWorkflowRunID:  []int64{25027630970},
-			wantWorkflowID:     []int64{9876543210},
+			wantLen:           1,
+			wantName:          []string{"test"},
+			wantWorkflowName:  []string{"CI"},
+			wantWorkflowRunID: []int64{25027630970},
+			wantWorkflowID:    []int64{9876543210},
 		},
 		{
 			name: "WorkflowName takes priority over AppName",
@@ -377,8 +377,8 @@ func TestContextNodesToCheckRuns(t *testing.T) {
 				makeCheckRunNode(checkRunContextFields{
 					Name:       "Checkov",
 					Status:     "COMPLETED",
-					Conclusion:  "SUCCESS",
-					AppName:     "Bridgecrew",
+					Conclusion: "SUCCESS",
+					AppName:    "Bridgecrew",
 				}),
 			},
 			wantLen:          1,
@@ -675,6 +675,8 @@ func makeTestQuery(checkRunNames []string, hasNextPage bool, endCursor string, r
 
 	q.Repository.PullRequest.Commits.Nodes = []struct {
 		Commit struct {
+			PushedDate        githubv4.DateTime `graphql:"pushedDate"`
+			CommittedDate     githubv4.DateTime `graphql:"committedDate"`
 			StatusCheckRollup struct {
 				Contexts struct {
 					Nodes    []contextNode
@@ -702,7 +704,7 @@ func TestFetchCheckRunsGraphQL_SinglePage(t *testing.T) {
 		},
 	}
 
-	checkRuns, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	checkRuns, _, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -725,7 +727,7 @@ func TestFetchCheckRunsGraphQL_MultiPagePagination(t *testing.T) {
 		},
 	}
 
-	checkRuns, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	checkRuns, _, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -757,7 +759,7 @@ func TestFetchCheckRunsGraphQL_EmptyCommits(t *testing.T) {
 		responses: []mockResponse{{query: q}},
 	}
 
-	checkRuns, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	checkRuns, _, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -776,7 +778,7 @@ func TestFetchCheckRunsGraphQL_QueryError(t *testing.T) {
 		},
 	}
 
-	checkRuns, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	checkRuns, _, rateLimit, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -822,5 +824,79 @@ func TestBigInt_UnmarshalJSON(t *testing.T) {
 				t.Errorf("got %d, want %d", int64(b), tt.want)
 			}
 		})
+	}
+}
+
+// makeTestQueryWithPushTime builds a *pullRequestQuery like makeTestQuery but
+// also populates the head commit's PushedDate and CommittedDate so callers
+// can exercise the push-time extraction path in FetchCheckRunsGraphQL.
+func makeTestQueryWithPushTime(pushedDate, committedDate time.Time, rateLimitRemaining int) *pullRequestQuery {
+	q := makeTestQuery([]string{"lint"}, false, "", rateLimitRemaining)
+	commit := &q.Repository.PullRequest.Commits.Nodes[0]
+	if !pushedDate.IsZero() {
+		commit.Commit.PushedDate.Time = pushedDate
+	}
+	if !committedDate.IsZero() {
+		commit.Commit.CommittedDate.Time = committedDate
+	}
+	return q
+}
+
+// TestFetchCheckRunsGraphQL_HeadPushedTimeFromPushedDate asserts the push
+// time returned by FetchCheckRunsGraphQL is sourced from pushedDate when
+// both pushedDate and committedDate are present (issue #349).
+func TestFetchCheckRunsGraphQL_HeadPushedTimeFromPushedDate(t *testing.T) {
+	pushed := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	committed := pushed.Add(-2 * time.Hour) // older than pushed
+	mock := &mockQuerier{
+		responses: []mockResponse{
+			{query: makeTestQueryWithPushTime(pushed, committed, 4999)},
+		},
+	}
+
+	_, got, _, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(pushed) {
+		t.Errorf("HeadPushedTime = %v, want %v (pushedDate should win over committedDate)", got, pushed)
+	}
+}
+
+// TestFetchCheckRunsGraphQL_HeadPushedTimeFallsBackToCommittedDate
+// asserts that when pushedDate is absent (zero), committedDate is used.
+func TestFetchCheckRunsGraphQL_HeadPushedTimeFallsBackToCommittedDate(t *testing.T) {
+	committed := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mock := &mockQuerier{
+		responses: []mockResponse{
+			{query: makeTestQueryWithPushTime(time.Time{}, committed, 4999)},
+		},
+	}
+
+	_, got, _, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(committed) {
+		t.Errorf("HeadPushedTime = %v, want %v (committedDate fallback)", got, committed)
+	}
+}
+
+// TestFetchCheckRunsGraphQL_HeadPushedTimeZeroWhenAbsent asserts that when
+// neither pushedDate nor committedDate is present, the zero time is
+// returned so callers can render the fallback header.
+func TestFetchCheckRunsGraphQL_HeadPushedTimeZeroWhenAbsent(t *testing.T) {
+	mock := &mockQuerier{
+		responses: []mockResponse{
+			{query: makeTestQueryWithPushTime(time.Time{}, time.Time{}, 4999)},
+		},
+	}
+
+	_, got, _, err := fetchCheckRunsGraphQL(context.Background(), mock, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("HeadPushedTime = %v, want zero", got)
 	}
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -12,11 +12,18 @@ import (
 )
 
 var (
-	prURLPattern          = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)$`)
+	prURLPattern         = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)$`)
 	actionsRunURLPattern = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/actions/runs/(\d+)$`)
 )
 
-// PRInfo contains metadata about a pull request
+// PRInfo contains metadata about a pull request. HeadCommitDate is now
+// populated by the GraphQL check-runs query (FetchCheckRunsGraphQL) rather
+// than a separate REST Repositories.GetCommit call, because GraphQL exposes
+// pushedDate (which is what we actually want for queue latency and the
+// "Pushed Xs ago" label) while the REST commit endpoint only exposes the
+// committer/author timestamps. HeadCommitDate is retained as an empty string
+// for backwards compatibility but is unused by callers that have moved to
+// the GraphQL push time.
 type PRInfo struct {
 	Number         int
 	Title          string
@@ -114,7 +121,13 @@ func ParsePRURL(prURL string) (owner, repo string, prNumber int, err error) {
 	return matches[1], matches[2], prNum, nil
 }
 
-// FetchPRInfo retrieves metadata about a pull request
+// FetchPRInfo retrieves metadata about a pull request. Only the PR-level
+// fields (number, title, head SHA, created-at) come from REST; the head
+// commit's push time is sourced from the GraphQL check-runs query
+// (FetchCheckRunsGraphQL) which fetches pushedDate in the same round-trip
+// as the StatusCheckRollup. HeadCommitDate is left empty here for
+// backwards compatibility; callers that need the push time should consume
+// the time.Time returned by FetchCheckRunsGraphQL.
 func FetchPRInfo(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (*PRInfo, error) {
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
@@ -123,22 +136,10 @@ func FetchPRInfo(ctx context.Context, client *github.Client, owner, repo string,
 
 	headSHA := pr.GetHead().GetSHA()
 
-	// Fetch the commit to get its timestamp
-	commit, _, err := client.Repositories.GetCommit(ctx, owner, repo, headSHA, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch commit %s: %w", headSHA, err)
-	}
-
-	commitDate := ""
-	if !commit.GetCommit().GetCommitter().GetDate().IsZero() {
-		commitDate = commit.GetCommit().GetCommitter().GetDate().Format(TimestampFormat)
-	}
-
 	return &PRInfo{
-		Number:         prNumber,
-		Title:          pr.GetTitle(),
-		HeadSHA:        headSHA,
-		CreatedAt:      pr.GetCreatedAt().Format(TimestampFormat),
-		HeadCommitDate: commitDate,
+		Number:    prNumber,
+		Title:     pr.GetTitle(),
+		HeadSHA:   headSHA,
+		CreatedAt: pr.GetCreatedAt().Format(TimestampFormat),
 	}, nil
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -16,20 +16,17 @@ var (
 	actionsRunURLPattern = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/actions/runs/(\d+)$`)
 )
 
-// PRInfo contains metadata about a pull request. HeadCommitDate is now
-// populated by the GraphQL check-runs query (FetchCheckRunsGraphQL) rather
-// than a separate REST Repositories.GetCommit call, because GraphQL exposes
-// pushedDate (which is what we actually want for queue latency and the
-// "Pushed Xs ago" label) while the REST commit endpoint only exposes the
-// committer/author timestamps. HeadCommitDate is retained as an empty string
-// for backwards compatibility but is unused by callers that have moved to
-// the GraphQL push time.
+// PRInfo contains metadata about a pull request. Only PR-level fields
+// (number, title, head SHA, created-at) come from REST; the head commit's
+// push time is sourced separately from the GraphQL check-runs query
+// (FetchCheckRunsGraphQL), which fetches pushedDate in the same round-trip
+// as the StatusCheckRollup. The REST commit endpoint only exposes
+// committer/author timestamps, not pushedDate, so it is not used here.
 type PRInfo struct {
-	Number         int
-	Title          string
-	HeadSHA        string
-	CreatedAt      string
-	HeadCommitDate string
+	Number    int
+	Title     string
+	HeadSHA   string
+	CreatedAt string
 }
 
 // parsePRViewWithRepo parses JSON output from 'gh pr view --json number,url'
@@ -125,8 +122,7 @@ func ParsePRURL(prURL string) (owner, repo string, prNumber int, err error) {
 // fields (number, title, head SHA, created-at) come from REST; the head
 // commit's push time is sourced from the GraphQL check-runs query
 // (FetchCheckRunsGraphQL) which fetches pushedDate in the same round-trip
-// as the StatusCheckRollup. HeadCommitDate is left empty here for
-// backwards compatibility; callers that need the push time should consume
+// as the StatusCheckRollup. Callers that need the push time should consume
 // the time.Time returned by FetchCheckRunsGraphQL.
 func FetchPRInfo(ctx context.Context, client *github.Client, owner, repo string, prNumber int) (*PRInfo, error) {
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)

--- a/internal/github/repo_graphql.go
+++ b/internal/github/repo_graphql.go
@@ -22,11 +22,13 @@ const maxPRsPerQuery = 10
 // PRCheckData holds check run data for a single PR in repo mode.
 // HeadSHA is the PR head commit OID, used to dedupe standalone branch runs
 // (see RepoModel.dedupeAndAttachExtraJobs) against the PR section.
+// HeadPushedTime is the head commit's pushedDate (with committedDate as a
+// fallback), used for the queue-latency column and "Pushed Xs ago" header.
 type PRCheckData struct {
 	Number         int
 	Title          string
 	CheckRuns      []CheckRunInfo
-	HeadCommitTime time.Time
+	HeadPushedTime time.Time
 	HeadSHA        string
 }
 
@@ -151,16 +153,16 @@ func fetchRepoCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner
 		}
 
 		commit := pr.Commits.Nodes[0].Commit
-		var headCommitTime time.Time
+		var headPushedTime time.Time
 		if !commit.PushedDate.IsZero() {
-			headCommitTime = commit.PushedDate.Time
+			headPushedTime = commit.PushedDate.Time
 		} else if !commit.CommittedDate.IsZero() {
-			headCommitTime = commit.CommittedDate.Time
+			headPushedTime = commit.CommittedDate.Time
 		}
 
 		checkRuns := repoContextNodesToCheckRuns(commit.StatusCheckRollup.Contexts.Nodes)
 
-		if len(checkRuns) == 0 && headCommitTime.IsZero() {
+		if len(checkRuns) == 0 && headPushedTime.IsZero() {
 			continue
 		}
 
@@ -168,7 +170,7 @@ func fetchRepoCheckRunsGraphQL(ctx context.Context, client graphqlQuerier, owner
 			Number:         pr.Number,
 			Title:          pr.Title,
 			CheckRuns:      checkRuns,
-			HeadCommitTime: headCommitTime,
+			HeadPushedTime: headPushedTime,
 			HeadSHA:        string(commit.OID),
 		}
 	}

--- a/internal/github/runs.go
+++ b/internal/github/runs.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/fini-net/gh-observer/internal/debug"
 	"github.com/google/go-github/v90/github"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
 )
 
 // WorkflowJobInfo contains status data for a single job within a workflow run.
@@ -23,12 +26,18 @@ type WorkflowJobInfo struct {
 }
 
 // RunInfo contains metadata about a workflow run (for the header display).
+// HeadPushedTime is the time the run's head commit was pushed to GitHub
+// (sourced from GraphQL pushedDate, with committedDate as a fallback and
+// the REST head_commit.timestamp as a last resort when GraphQL is
+// unavailable). The "Pushed Xs ago" header renders this value, so it must
+// reflect the push event — not the (potentially much older) commit author
+// or committer timestamp (issue #349).
 type RunInfo struct {
 	ID             int64
 	DisplayTitle   string
 	HeadSHA        string
 	HeadCommitMsg  string
-	HeadCommitTime *github.Timestamp
+	HeadPushedTime *github.Timestamp
 	CreatedAt      *github.Timestamp
 	RunStartedAt   *github.Timestamp
 	Status         string
@@ -45,7 +54,72 @@ func firstLine(s string) string {
 	return strings.TrimSpace(line)
 }
 
-// FetchRunInfo retrieves metadata for a workflow run by its ID.
+// commitPushedDateQuery resolves the push time of a single commit via
+// GraphQL. The Actions REST API exposes only head_commit.timestamp (the
+// committer date), not the push time, so a small GraphQL lookup against
+// Repository.commit(oid:) is required to obtain pushedDate (issue #349).
+// committedDate is also fetched as a fallback for rare cases where
+// pushedDate is absent (e.g. some tagged-release runs not tied to a push).
+type commitPushedDateQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				PushedDate    githubv4.DateTime `graphql:"pushedDate"`
+				CommittedDate githubv4.DateTime `graphql:"committedDate"`
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+// fetchCommitPushedTime looks up pushedDate (with committedDate fallback)
+// for the given SHA via a single GraphQL query. Returns the zero time
+// (and a nil error) when the lookup fails or returns no usable timestamp;
+// callers are expected to fall back to another source rather than abort.
+// The unexported helper takes a graphqlQuerier so tests can inject a mock;
+// the public caller builds the client from the token via the wrapper below.
+func fetchCommitPushedTimeWithClient(ctx context.Context, client graphqlQuerier, owner, repo, sha string) time.Time {
+	if sha == "" {
+		return time.Time{}
+	}
+
+	var q commitPushedDateQuery
+	variables := map[string]any{
+		"owner": githubv4.String(owner),
+		"repo":  githubv4.String(repo),
+		"oid":   githubv4.GitObjectID(sha),
+	}
+	if err := client.Query(ctx, &q, variables); err != nil {
+		debug.Log("commit pushedDate lookup failed", "owner", owner, "repo", repo, "sha", sha, "err", err)
+		return time.Time{}
+	}
+	if !q.Repository.Object.Commit.PushedDate.IsZero() {
+		return q.Repository.Object.Commit.PushedDate.Time
+	}
+	if !q.Repository.Object.Commit.CommittedDate.IsZero() {
+		return q.Repository.Object.Commit.CommittedDate.Time
+	}
+	return time.Time{}
+}
+
+// fetchCommitPushedTime builds an authenticated GraphQL client from token
+// and delegates to fetchCommitPushedTimeWithClient. A missing token yields
+// the zero time (callers fall back to the REST timestamp).
+func fetchCommitPushedTime(ctx context.Context, token, owner, repo, sha string) time.Time {
+	if token == "" {
+		return time.Time{}
+	}
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(ctx, src)
+	client := githubv4.NewClient(httpClient)
+	return fetchCommitPushedTimeWithClient(ctx, client, owner, repo, sha)
+}
+
+// FetchRunInfo retrieves metadata for a workflow run by its ID. The head
+// commit's push time is sourced from a GraphQL pushedDate lookup (with
+// committedDate fallback); if that lookup fails, it falls back to the
+// REST head_commit.timestamp so the "Pushed Xs ago" header still renders.
+// A non-empty token is required for the GraphQL path; without it the REST
+// fallback is used directly.
 func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string, runID int64) (*RunInfo, error) {
 	run, _, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
 	if err != nil {
@@ -53,8 +127,8 @@ func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string
 	}
 
 	info := &RunInfo{
-		ID:       run.GetID(),
-		Status:   run.GetStatus(),
+		ID:         run.GetID(),
+		Status:     run.GetStatus(),
 		WorkflowID: run.GetWorkflowID(),
 	}
 
@@ -71,7 +145,12 @@ func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string
 		if run.HeadCommit.Message != nil {
 			info.HeadCommitMsg = firstLine(*run.HeadCommit.Message)
 		}
-		info.HeadCommitTime = run.HeadCommit.Timestamp
+		// REST fallback: head_commit.timestamp is the committer date, not
+		// the push time. Used only if the GraphQL lookup below fails or
+		// returns no timestamp (issue #349).
+		if run.HeadCommit.Timestamp != nil {
+			info.HeadPushedTime = run.HeadCommit.Timestamp
+		}
 	}
 	if run.CreatedAt != nil {
 		info.CreatedAt = run.CreatedAt
@@ -81,6 +160,17 @@ func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string
 	}
 	if run.Conclusion != nil {
 		info.Conclusion = *run.Conclusion
+	}
+
+	// Best-effort GraphQL lookup of pushedDate: if it succeeds, replace
+	// the REST fallback with the real push time. A failure leaves the
+	// fallback in place and is logged, not surfaced — the header still
+	// renders (just with a slightly older timestamp).
+	if info.HeadSHA != "" {
+		token, _ := GetToken()
+		if pushed := fetchCommitPushedTime(ctx, token, owner, repo, info.HeadSHA); !pushed.IsZero() {
+			info.HeadPushedTime = &github.Timestamp{Time: pushed}
+		}
 	}
 
 	debug.Log("fetch run info", "run_id", runID, "name", info.DisplayTitle, "status", info.Status)
@@ -159,7 +249,7 @@ func WorkflowJobInfoToCheckRuns(jobs []WorkflowJobInfo) []CheckRunInfo {
 			WorkflowName:  job.WorkflowName,
 			Status:        job.Status,
 			Conclusion:    job.Conclusion,
-			DetailsURL:   job.HTMLURL,
+			DetailsURL:    job.HTMLURL,
 			WorkflowRunID: job.RunID,
 			WorkflowID:    job.WorkflowID,
 		}

--- a/internal/github/runs.go
+++ b/internal/github/runs.go
@@ -57,9 +57,12 @@ func firstLine(s string) string {
 // commitPushedDateQuery resolves the push time of a single commit via
 // GraphQL. The Actions REST API exposes only head_commit.timestamp (the
 // committer date), not the push time, so a small GraphQL lookup against
-// Repository.commit(oid:) is required to obtain pushedDate (issue #349).
-// committedDate is also fetched as a fallback for rare cases where
-// pushedDate is absent (e.g. some tagged-release runs not tied to a push).
+// Repository.object(oid:) ... on Commit is required to obtain pushedDate
+// (issue #349). committedDate is also fetched as a fallback for rare
+// cases where pushedDate is absent (e.g. some tagged-release runs not
+// tied to a push). RateLimit is requested for consistency with the
+// codebase's other GraphQL queries so this one-shot call participates in
+// the app's rate-limit accounting.
 type commitPushedDateQuery struct {
 	Repository struct {
 		Object struct {
@@ -69,17 +72,23 @@ type commitPushedDateQuery struct {
 			} `graphql:"... on Commit"`
 		} `graphql:"object(oid: $oid)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
+	RateLimit struct {
+		Remaining int
+	}
 }
 
 // fetchCommitPushedTime looks up pushedDate (with committedDate fallback)
 // for the given SHA via a single GraphQL query. Returns the zero time
 // when the lookup fails or returns no usable timestamp; callers are
-// expected to fall back to another source rather than abort.
+// expected to fall back to another source rather than abort. The second
+// return value is the GraphQL rate limit remaining after the call (0 on
+// error or when the query is skipped), so callers can fold it into the
+// app's rate-limit accounting alongside other GraphQL queries.
 // The unexported helper takes a graphqlQuerier so tests can inject a mock;
 // the public caller builds the client from the token via the wrapper below.
-func fetchCommitPushedTimeWithClient(ctx context.Context, client graphqlQuerier, owner, repo, sha string) time.Time {
+func fetchCommitPushedTimeWithClient(ctx context.Context, client graphqlQuerier, owner, repo, sha string) (time.Time, int) {
 	if sha == "" {
-		return time.Time{}
+		return time.Time{}, 0
 	}
 
 	var q commitPushedDateQuery
@@ -90,23 +99,26 @@ func fetchCommitPushedTimeWithClient(ctx context.Context, client graphqlQuerier,
 	}
 	if err := client.Query(ctx, &q, variables); err != nil {
 		debug.Log("commit pushedDate lookup failed", "owner", owner, "repo", repo, "sha", sha, "err", err)
-		return time.Time{}
+		return time.Time{}, 0
 	}
+	rateLimitRemaining := q.RateLimit.Remaining
+	debug.Log("commit pushedDate lookup", "owner", owner, "repo", repo, "sha", sha, "rate_limit_remaining", rateLimitRemaining)
 	if !q.Repository.Object.Commit.PushedDate.IsZero() {
-		return q.Repository.Object.Commit.PushedDate.Time
+		return q.Repository.Object.Commit.PushedDate.Time, rateLimitRemaining
 	}
 	if !q.Repository.Object.Commit.CommittedDate.IsZero() {
-		return q.Repository.Object.Commit.CommittedDate.Time
+		return q.Repository.Object.Commit.CommittedDate.Time, rateLimitRemaining
 	}
-	return time.Time{}
+	return time.Time{}, rateLimitRemaining
 }
 
 // fetchCommitPushedTime builds an authenticated GraphQL client from token
 // and delegates to fetchCommitPushedTimeWithClient. A missing token yields
-// the zero time (callers fall back to the REST timestamp).
-func fetchCommitPushedTime(ctx context.Context, token, owner, repo, sha string) time.Time {
+// the zero time and a 0 rate limit (callers fall back to the REST
+// timestamp and keep their existing rate-limit value).
+func fetchCommitPushedTime(ctx context.Context, token, owner, repo, sha string) (time.Time, int) {
 	if token == "" {
-		return time.Time{}
+		return time.Time{}, 0
 	}
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(ctx, src)
@@ -122,10 +134,18 @@ func fetchCommitPushedTime(ctx context.Context, token, owner, repo, sha string) 
 // fallback is used directly. Callers that already hold a token should pass
 // it here rather than letting this function re-derive it via GetToken()
 // (which may shell out to `gh auth token`).
-func FetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo string, runID int64) (*RunInfo, error) {
+//
+// The second return value is the GitHub API rate limit remaining after the
+// GraphQL lookup (or 5000 — the REST default — when the lookup is skipped
+// or fails, since the REST GetWorkflowRunByID call does not expose a
+// remaining count in a way this function threads back). Callers should
+// fold it into their rate-limit accounting; when the GraphQL call
+// succeeds its observed value is returned, which may be lower than the
+// REST-side reality and is intentionally conservative.
+func FetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo string, runID int64) (*RunInfo, int, error) {
 	run, _, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch workflow run %d: %w", runID, err)
+		return nil, 5000, fmt.Errorf("failed to fetch workflow run %d: %w", runID, err)
 	}
 
 	info := &RunInfo{
@@ -164,19 +184,30 @@ func FetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo
 		info.Conclusion = *run.Conclusion
 	}
 
+	// Conservative default: matches FetchRunJobs's sentinel when no
+	// GraphQL rate-limit observation is available. The GraphQL lookup
+	// below replaces it with the real observed value when it succeeds.
+	rateLimitRemaining := 5000
+
 	// Best-effort GraphQL lookup of pushedDate: if it succeeds, replace
 	// the REST fallback with the real push time. A failure leaves the
 	// fallback in place and is logged, not surfaced — the header still
-	// renders (just with a slightly older timestamp).
+	// renders (just with a slightly older timestamp). The rate limit
+	// returned by the lookup is surfaced to the caller even on timestamp
+	// miss so the app's backoff accounting sees this one-shot call.
 	if info.HeadSHA != "" {
-		if pushed := fetchCommitPushedTime(ctx, token, owner, repo, info.HeadSHA); !pushed.IsZero() {
+		pushed, rl := fetchCommitPushedTime(ctx, token, owner, repo, info.HeadSHA)
+		if rl > 0 {
+			rateLimitRemaining = rl
+		}
+		if !pushed.IsZero() {
 			info.HeadPushedTime = &github.Timestamp{Time: pushed}
 		}
 	}
 
-	debug.Log("fetch run info", "run_id", runID, "name", info.DisplayTitle, "status", info.Status)
+	debug.Log("fetch run info", "run_id", runID, "name", info.DisplayTitle, "status", info.Status, "rate_limit_remaining", rateLimitRemaining)
 
-	return info, nil
+	return info, rateLimitRemaining, nil
 }
 
 // FetchRunJobs retrieves the jobs for a workflow run by its ID.

--- a/internal/github/runs.go
+++ b/internal/github/runs.go
@@ -73,8 +73,8 @@ type commitPushedDateQuery struct {
 
 // fetchCommitPushedTime looks up pushedDate (with committedDate fallback)
 // for the given SHA via a single GraphQL query. Returns the zero time
-// (and a nil error) when the lookup fails or returns no usable timestamp;
-// callers are expected to fall back to another source rather than abort.
+// when the lookup fails or returns no usable timestamp; callers are
+// expected to fall back to another source rather than abort.
 // The unexported helper takes a graphqlQuerier so tests can inject a mock;
 // the public caller builds the client from the token via the wrapper below.
 func fetchCommitPushedTimeWithClient(ctx context.Context, client graphqlQuerier, owner, repo, sha string) time.Time {
@@ -119,8 +119,10 @@ func fetchCommitPushedTime(ctx context.Context, token, owner, repo, sha string) 
 // committedDate fallback); if that lookup fails, it falls back to the
 // REST head_commit.timestamp so the "Pushed Xs ago" header still renders.
 // A non-empty token is required for the GraphQL path; without it the REST
-// fallback is used directly.
-func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string, runID int64) (*RunInfo, error) {
+// fallback is used directly. Callers that already hold a token should pass
+// it here rather than letting this function re-derive it via GetToken()
+// (which may shell out to `gh auth token`).
+func FetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo string, runID int64) (*RunInfo, error) {
 	run, _, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch workflow run %d: %w", runID, err)
@@ -167,7 +169,6 @@ func FetchRunInfo(ctx context.Context, client *github.Client, owner, repo string
 	// fallback in place and is logged, not surfaced — the header still
 	// renders (just with a slightly older timestamp).
 	if info.HeadSHA != "" {
-		token, _ := GetToken()
 		if pushed := fetchCommitPushedTime(ctx, token, owner, repo, info.HeadSHA); !pushed.IsZero() {
 			info.HeadPushedTime = &github.Timestamp{Time: pushed}
 		}

--- a/internal/github/runs_test.go
+++ b/internal/github/runs_test.go
@@ -295,11 +295,15 @@ func TestFetchCommitPushedTime_PushedDateWins(t *testing.T) {
 	resp := commitPushedDateQuery{}
 	resp.Repository.Object.Commit.PushedDate.Time = pushed
 	resp.Repository.Object.Commit.CommittedDate.Time = committed
+	resp.RateLimit.Remaining = 4999
 
 	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{resp}}
-	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	got, rl := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
 	if !got.Equal(pushed) {
 		t.Errorf("got %v, want %v (pushedDate should win)", got, pushed)
+	}
+	if rl != 4999 {
+		t.Errorf("rate limit = %d, want 4999", rl)
 	}
 }
 
@@ -310,45 +314,62 @@ func TestFetchCommitPushedTime_FallsBackToCommittedDate(t *testing.T) {
 
 	resp := commitPushedDateQuery{}
 	resp.Repository.Object.Commit.CommittedDate.Time = committed
+	resp.RateLimit.Remaining = 4998
 
 	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{resp}}
-	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	got, rl := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
 	if !got.Equal(committed) {
 		t.Errorf("got %v, want %v (committedDate fallback)", got, committed)
+	}
+	if rl != 4998 {
+		t.Errorf("rate limit = %d, want 4998", rl)
 	}
 }
 
 // TestFetchCommitPushedTime_ZeroWhenAbsent asserts the zero time is
-// returned when neither date is present so callers can fall back to REST.
+// returned when neither date is present so callers can fall back to REST,
+// while the rate limit is still surfaced for the caller's accounting.
 func TestFetchCommitPushedTime_ZeroWhenAbsent(t *testing.T) {
-	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{{}}}
-	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	resp := commitPushedDateQuery{}
+	resp.RateLimit.Remaining = 4997
+	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{resp}}
+	got, rl := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
 	if !got.IsZero() {
 		t.Errorf("got %v, want zero", got)
+	}
+	if rl != 4997 {
+		t.Errorf("rate limit = %d, want 4997", rl)
 	}
 }
 
 // TestFetchCommitPushedTime_ZeroOnQueryError asserts a GraphQL error
-// yields the zero time so the caller keeps the REST fallback rather than
-// crashing (issue #349 robustness criterion).
+// yields the zero time and a 0 rate limit so the caller keeps the REST
+// fallback rather than crashing (issue #349 robustness criterion).
 func TestFetchCommitPushedTime_ZeroOnQueryError(t *testing.T) {
 	mock := &mockPushedDateQuerier{
 		responses: []commitPushedDateQuery{{}},
 		errs:      []error{fmt.Errorf("network error")},
 	}
-	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	got, rl := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
 	if !got.IsZero() {
 		t.Errorf("got %v, want zero on query error", got)
+	}
+	if rl != 0 {
+		t.Errorf("rate limit = %d, want 0 on query error", rl)
 	}
 }
 
 // TestFetchCommitPushedTime_ZeroForEmptySHA guards against the GraphQL
-// helper being invoked with an empty SHA (would 404).
+// helper being invoked with an empty SHA (would 404). No GraphQL call
+// should be made, and the rate limit must be 0 (no observation).
 func TestFetchCommitPushedTime_ZeroForEmptySHA(t *testing.T) {
 	mock := &mockPushedDateQuerier{}
-	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "")
+	got, rl := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "")
 	if !got.IsZero() {
 		t.Errorf("got %v, want zero for empty SHA", got)
+	}
+	if rl != 0 {
+		t.Errorf("rate limit = %d, want 0 for empty SHA", rl)
 	}
 	if mock.calls != 0 {
 		t.Errorf("expected 0 GraphQL calls for empty SHA, got %d", mock.calls)

--- a/internal/github/runs_test.go
+++ b/internal/github/runs_test.go
@@ -1,10 +1,13 @@
 package github
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-github/v90/github"
+	"github.com/shurcooL/githubv4"
 )
 
 func TestFirstLine(t *testing.T) {
@@ -256,3 +259,104 @@ func TestFailureJobConclusion(t *testing.T) {
 		})
 	}
 }
+
+// mockPushedDateQuerier returns a sequence of canned commitPushedDateQuery
+// responses (or errors). Mirrors mockQuerier in graphql_test.go but for
+// the run-mode commit-push-time query.
+type mockPushedDateQuerier struct {
+	responses []commitPushedDateQuery
+	errs      []error
+	calls     int
+}
+
+func (m *mockPushedDateQuerier) Query(_ context.Context, q interface{}, _ map[string]interface{}) error {
+	if m.calls >= len(m.responses) && m.calls >= len(m.errs) {
+		return fmt.Errorf("unexpected query call #%d", m.calls+1)
+	}
+	var err error
+	if m.calls < len(m.errs) && m.errs[m.calls] != nil {
+		err = m.errs[m.calls]
+	}
+	if err == nil {
+		resp := m.responses[m.calls]
+		target := q.(*commitPushedDateQuery)
+		*target = resp
+	}
+	m.calls++
+	return err
+}
+
+// TestFetchCommitPushedTime_PushedDateWins asserts pushedDate is returned
+// when both pushedDate and committedDate are present (issue #349).
+func TestFetchCommitPushedTime_PushedDateWins(t *testing.T) {
+	pushed := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	committed := pushed.Add(-2 * time.Hour)
+
+	resp := commitPushedDateQuery{}
+	resp.Repository.Object.Commit.PushedDate.Time = pushed
+	resp.Repository.Object.Commit.CommittedDate.Time = committed
+
+	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{resp}}
+	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	if !got.Equal(pushed) {
+		t.Errorf("got %v, want %v (pushedDate should win)", got, pushed)
+	}
+}
+
+// TestFetchCommitPushedTime_FallsBackToCommittedDate asserts the
+// committedDate fallback when pushedDate is absent.
+func TestFetchCommitPushedTime_FallsBackToCommittedDate(t *testing.T) {
+	committed := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	resp := commitPushedDateQuery{}
+	resp.Repository.Object.Commit.CommittedDate.Time = committed
+
+	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{resp}}
+	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	if !got.Equal(committed) {
+		t.Errorf("got %v, want %v (committedDate fallback)", got, committed)
+	}
+}
+
+// TestFetchCommitPushedTime_ZeroWhenAbsent asserts the zero time is
+// returned when neither date is present so callers can fall back to REST.
+func TestFetchCommitPushedTime_ZeroWhenAbsent(t *testing.T) {
+	mock := &mockPushedDateQuerier{responses: []commitPushedDateQuery{{}}}
+	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	if !got.IsZero() {
+		t.Errorf("got %v, want zero", got)
+	}
+}
+
+// TestFetchCommitPushedTime_ZeroOnQueryError asserts a GraphQL error
+// yields the zero time so the caller keeps the REST fallback rather than
+// crashing (issue #349 robustness criterion).
+func TestFetchCommitPushedTime_ZeroOnQueryError(t *testing.T) {
+	mock := &mockPushedDateQuerier{
+		responses: []commitPushedDateQuery{{}},
+		errs:      []error{fmt.Errorf("network error")},
+	}
+	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "deadbeef")
+	if !got.IsZero() {
+		t.Errorf("got %v, want zero on query error", got)
+	}
+}
+
+// TestFetchCommitPushedTime_ZeroForEmptySHA guards against the GraphQL
+// helper being invoked with an empty SHA (would 404).
+func TestFetchCommitPushedTime_ZeroForEmptySHA(t *testing.T) {
+	mock := &mockPushedDateQuerier{}
+	got := fetchCommitPushedTimeWithClient(context.Background(), mock, "owner", "repo", "")
+	if !got.IsZero() {
+		t.Errorf("got %v, want zero for empty SHA", got)
+	}
+	if mock.calls != 0 {
+		t.Errorf("expected 0 GraphQL calls for empty SHA, got %d", mock.calls)
+	}
+}
+
+// Compile-time guard: confirm githubv4.GitObjectID is used correctly in
+// fetchCommitPushedTimeWithClient's variables map. If the githubv4 API
+// changes the type, this will surface at compile time rather than at the
+// first real run.
+var _ githubv4.GitObjectID = githubv4.GitObjectID("")

--- a/internal/github/runs_test.go
+++ b/internal/github/runs_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/go-github/v90/github"
-	"github.com/shurcooL/githubv4"
 )
 
 func TestFirstLine(t *testing.T) {
@@ -375,9 +374,3 @@ func TestFetchCommitPushedTime_ZeroForEmptySHA(t *testing.T) {
 		t.Errorf("expected 0 GraphQL calls for empty SHA, got %d", mock.calls)
 	}
 }
-
-// Compile-time guard: confirm githubv4.GitObjectID is used correctly in
-// fetchCommitPushedTimeWithClient's variables map. If the githubv4 API
-// changes the type, this will surface at compile time rather than at the
-// first real run.
-var _ githubv4.GitObjectID = githubv4.GitObjectID("")

--- a/internal/timing/calculator.go
+++ b/internal/timing/calculator.go
@@ -7,12 +7,17 @@ import (
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 )
 
-// QueueLatency calculates the time from commit push to check start
-func QueueLatency(commitTime time.Time, check ghclient.CheckRunInfo) time.Duration {
-	if check.StartedAt == nil || commitTime.IsZero() {
+// QueueLatency calculates the time from commit push to check start. The
+// pushTime parameter should be the head commit's pushedDate (not the
+// commit-author or committer timestamp): GitHub's actions-queue delay is
+// the gap between when a commit is pushed and when the first check on it
+// starts, and only pushedDate captures that. A zero pushTime (e.g.
+// GraphQL lookup failed) returns 0 so the caller can render a placeholder.
+func QueueLatency(pushTime time.Time, check ghclient.CheckRunInfo) time.Duration {
+	if check.StartedAt == nil || pushTime.IsZero() {
 		return 0
 	}
-	return check.StartedAt.Sub(commitTime)
+	return check.StartedAt.Sub(pushTime)
 }
 
 // Runtime calculates elapsed time for in_progress checks

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -31,16 +31,22 @@ const maxCheckNameWidth = 60
 // on the literal string — same rationale as maxCheckNameWidth above.
 const copilotRowKind = "review"
 
-// FormatQueueLatency returns the queue time text or placeholder
-func FormatQueueLatency(check ghclient.CheckRunInfo, headCommitTime time.Time) string {
+// FormatQueueLatency returns the queue time text or placeholder. The
+// headPushedTime parameter is the PR head commit's push time (not the
+// commit-author time): for a queued check this shows "how long since the
+// push" (a stand-in for "how long until the check starts"), and for a
+// started check it backs the QueueLatency calculation (check.StartedAt -
+// pushedAt) which represents how long GitHub took to start the check after
+// the commit was pushed.
+func FormatQueueLatency(check ghclient.CheckRunInfo, headPushedTime time.Time) string {
 	if check.Status == "queued" {
-		if !headCommitTime.IsZero() {
-			return timing.FormatDuration(time.Since(headCommitTime))
+		if !headPushedTime.IsZero() {
+			return timing.FormatDuration(time.Since(headPushedTime))
 		}
 		return "-"
 	}
 
-	queueLatency := timing.QueueLatency(headCommitTime, check)
+	queueLatency := timing.QueueLatency(headPushedTime, check)
 	if queueLatency > 0 {
 		return timing.FormatDuration(queueLatency)
 	}
@@ -206,7 +212,7 @@ func FormatAvg(check ghclient.CheckRunInfo, jobAverages map[string]time.Duration
 }
 
 // CalculateColumnWidths scans all check runs and determines max width for each column
-func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime time.Time, jobAverages map[string]time.Duration) ColumnWidths {
+func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headPushedTime time.Time, jobAverages map[string]time.Duration) ColumnWidths {
 	const (
 		minNameWidth = 20
 		minTimeWidth = 5
@@ -220,7 +226,7 @@ func CalculateColumnWidths(checkRuns []ghclient.CheckRunInfo, headCommitTime tim
 	}
 
 	for _, check := range checkRuns {
-		queueText := FormatQueueLatency(check, headCommitTime)
+		queueText := FormatQueueLatency(check, headPushedTime)
 		if runewidth.StringWidth(queueText) > widths.QueueWidth {
 			widths.QueueWidth = runewidth.StringWidth(queueText)
 		}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -9,19 +9,25 @@ import (
 // TickMsg is sent on each poll interval
 type TickMsg time.Time
 
-// PRInfoMsg contains PR metadata
+// PRInfoMsg contains PR metadata. HeadCommitTime was previously sourced from
+// the REST commit fetch in FetchPRInfo; that fetch has been removed (issue
+// #349) and the push time now arrives via ChecksUpdateMsg from the GraphQL
+// check-runs query (which selects pushedDate in the same round-trip).
 type PRInfoMsg struct {
-	Number         int
-	Title          string
-	HeadSHA        string
-	CreatedAt      time.Time
-	HeadCommitTime time.Time
-	Err            error
+	Number    int
+	Title     string
+	HeadSHA   string
+	CreatedAt time.Time
+	Err       error
 }
 
-// ChecksUpdateMsg contains updated check runs
+// ChecksUpdateMsg contains updated check runs. HeadPushedTime carries the
+// PR head commit's push time (pushedDate, with committedDate fallback)
+// sourced from the same GraphQL query that produced CheckRuns. Callers
+// use it for the "Pushed Xs ago" header and the queue-latency column.
 type ChecksUpdateMsg struct {
 	CheckRuns          []ghclient.CheckRunInfo
+	HeadPushedTime     time.Time
 	RateLimitRemaining int
 	Err                error
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -20,7 +20,7 @@ type Model struct {
 	prTitle        string
 	headSHA        string
 	prCreatedAt    time.Time
-	headCommitTime time.Time
+	headPushedTime time.Time
 
 	// Check runs
 	checkRuns []ghclient.CheckRunInfo
@@ -53,7 +53,7 @@ type Model struct {
 	// Historical job averages (incrementally updated as new workflows appear)
 	jobAverages             map[string]time.Duration
 	workflowAverages        map[int64]map[string]time.Duration
-	advSecMatchWorkflow    map[string]int64
+	advSecMatchWorkflow     map[string]int64
 	runIDToWorkflowID       map[int64]int64
 	fetchedWorkflowIDs      map[int64]bool
 	pendingWorkflowFetch    map[int64]bool
@@ -94,18 +94,18 @@ type Model struct {
 	// proceeding. copilotPollStartTime is set to now + initialDelay and gates
 	// when the first Copilot review poll may fire (gives GitHub time to create
 	// the review request after a push).
-	waitForCopilot         bool
-	copilotMaxWait         time.Duration
-	copilotPollInterval    time.Duration
-	copilotInitialDelay    time.Duration
-	copilotState           string
-	copilotStale           bool
-	copilotPending         bool
-	copilotWaitStartTime   time.Time
-	copilotPollStartTime   time.Time
-	copilotLastPoll        time.Time
-	copilotNotReqStreak    int
-	copilotReviewComplete  bool
+	waitForCopilot        bool
+	copilotMaxWait        time.Duration
+	copilotPollInterval   time.Duration
+	copilotInitialDelay   time.Duration
+	copilotState          string
+	copilotStale          bool
+	copilotPending        bool
+	copilotWaitStartTime  time.Time
+	copilotPollStartTime  time.Time
+	copilotLastPoll       time.Time
+	copilotNotReqStreak   int
+	copilotReviewComplete bool
 }
 
 // NewModel creates a new TUI model
@@ -127,12 +127,12 @@ func NewModel(ctx context.Context, token, owner, repo string, prNumber int, refr
 		noAvg:                   noAvg,
 		jobAverages:             make(map[string]time.Duration),
 		workflowAverages:        make(map[int64]map[string]time.Duration),
-		advSecMatchWorkflow:    make(map[string]int64),
+		advSecMatchWorkflow:     make(map[string]int64),
 		runIDToWorkflowID:       make(map[int64]int64),
 		fetchedWorkflowIDs:      make(map[int64]bool),
 		pendingWorkflowFetch:    make(map[int64]bool),
 		dispatchedWorkflowFetch: make(map[int64]bool),
-		seenCheckKeys:          make(map[string]bool),
+		seenCheckKeys:           make(map[string]bool),
 		presumedAverages:        presumedAverages,
 		waitForCopilot:          waitForCopilot,
 		copilotMaxWait:          copilotMaxWait,

--- a/internal/tui/repomodel.go
+++ b/internal/tui/repomodel.go
@@ -23,7 +23,7 @@ type PRViewData struct {
 	Title          string
 	CheckRuns      []ghclient.CheckRunInfo
 	ExtraCheckRuns []ghclient.CheckRunInfo
-	HeadCommitTime time.Time
+	HeadPushedTime time.Time
 	HeadSHA        string
 }
 

--- a/internal/tui/repoupdate.go
+++ b/internal/tui/repoupdate.go
@@ -143,7 +143,7 @@ func (m *RepoModel) handleRepoChecksUpdate(msg RepoChecksUpdateMsg) (tea.Model, 
 		view := PRViewData{
 			Title:          prData.Title,
 			CheckRuns:      visible,
-			HeadCommitTime: prData.HeadCommitTime,
+			HeadPushedTime: prData.HeadPushedTime,
 			HeadSHA:        prData.HeadSHA,
 		}
 		// Preserve extras carried over from the last runs-poll so they

--- a/internal/tui/repoupdate_test.go
+++ b/internal/tui/repoupdate_test.go
@@ -378,7 +378,7 @@ func TestRepoChecksUpdateErrorNonFatal(t *testing.T) {
 					{Status: "in_progress", Name: "build"},
 					{Status: "completed", Conclusion: "success", Name: "lint", CompletedAt: &goodCompletedAt},
 				},
-				HeadCommitTime: now.Add(-2 * time.Minute),
+				HeadPushedTime: now.Add(-2 * time.Minute),
 			},
 		},
 		fadeSuccess:        fadeSuccess,
@@ -1151,7 +1151,7 @@ func TestRepoRunsDedupDropsStaleExtras(t *testing.T) {
 	// New runs poll reports no runs at all for this SHA — the Copilot run
 	// has faded. The stale extra must be dropped, not carried forward.
 	msg := RepoRunsUpdateMsg{
-		Runs:             []ghclient.BranchRunData{},
+		Runs:               []ghclient.BranchRunData{},
 		RateLimitRemaining: 5000,
 	}
 
@@ -1198,7 +1198,7 @@ func TestRepoRunsDedupReattachesStillVisibleExtra(t *testing.T) {
 				Status:  "in_progress",
 				Jobs: []ghclient.CheckRunInfo{
 					makeDedupBranchJob("CI", "build"), // duplicate
-					copilot, // still present, should re-attach
+					copilot,                           // still present, should re-attach
 				},
 			},
 		},

--- a/internal/tui/repoview.go
+++ b/internal/tui/repoview.go
@@ -129,10 +129,10 @@ func (m RepoModel) renderPRGroup(b *strings.Builder, prNum int, prData PRViewDat
 	}
 
 	SortCheckRuns(merged)
-	widths := CalculateColumnWidths(merged, prData.HeadCommitTime, nil)
+	widths := CalculateColumnWidths(merged, prData.HeadPushedTime, nil)
 
 	for _, check := range merged {
-		line := m.renderRepoCheckRun(check, prData.HeadCommitTime, widths)
+		line := m.renderRepoCheckRun(check, prData.HeadPushedTime, widths)
 		b.WriteString(line)
 	}
 
@@ -141,9 +141,9 @@ func (m RepoModel) renderPRGroup(b *strings.Builder, prNum int, prData PRViewDat
 
 // renderRepoCheckRun renders one PR check row, indented two spaces under the PR header.
 // Reuses display.go helpers (no HistAvg column — jobAverages is nil in repo mode).
-func (m RepoModel) renderRepoCheckRun(check ghclient.CheckRunInfo, headCommitTime time.Time, widths ColumnWidths) string {
+func (m RepoModel) renderRepoCheckRun(check ghclient.CheckRunInfo, headPushedTime time.Time, widths ColumnWidths) string {
 	nameCol := BuildNameColumn(check, widths, m.enableLinks)
-	queueText := FormatQueueLatency(check, headCommitTime)
+	queueText := FormatQueueLatency(check, headPushedTime)
 	durationText := FormatDuration(check)
 	avgText := FormatAvg(check, nil)
 

--- a/internal/tui/runupdate.go
+++ b/internal/tui/runupdate.go
@@ -52,7 +52,7 @@ type RunErrorMsg struct {
 func (m RunModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
-		fetchRunInfo(m.ctx, m.client, m.owner, m.repo, m.runID),
+		fetchRunInfo(m.ctx, m.client, m.token, m.owner, m.repo, m.runID),
 		runTick(m.refreshInterval),
 	)
 }
@@ -233,9 +233,9 @@ func runTick(d time.Duration) tea.Cmd {
 }
 
 // fetchRunInfo fetches workflow run metadata.
-func fetchRunInfo(ctx context.Context, client *github.Client, owner, repo string, runID int64) tea.Cmd {
+func fetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo string, runID int64) tea.Cmd {
 	return func() tea.Msg {
-		runInfo, err := ghclient.FetchRunInfo(ctx, client, owner, repo, runID)
+		runInfo, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
 		if err != nil {
 			return RunInfoMsg{Err: err}
 		}

--- a/internal/tui/runupdate.go
+++ b/internal/tui/runupdate.go
@@ -18,8 +18,9 @@ type RunTickMsg time.Time
 
 // RunInfoMsg contains run metadata.
 type RunInfoMsg struct {
-	RunInfo ghclient.RunInfo
-	Err     error
+	RunInfo            ghclient.RunInfo
+	RateLimitRemaining int
+	Err                error
 }
 
 // RunJobsUpdateMsg contains updated job statuses for a workflow run.
@@ -91,6 +92,14 @@ func (m RunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.runInfo = msg.RunInfo
 		m.runInfoLoaded = true
+		// Fold the GraphQL rate-limit observation from the pushedDate
+		// lookup into the model's accounting. Only mark fetchReceived
+		// when we actually got a value, so the zero-value default (0)
+		// doesn't suppress the first poll tick (see RunTickMsg handler).
+		if msg.RateLimitRemaining > 0 {
+			m.rateLimitRemaining = msg.RateLimitRemaining
+			m.fetchReceived = true
+		}
 		return m, fetchRunJobs(m.ctx, m.client, m.owner, m.repo, m.runID)
 
 	case RunJobsUpdateMsg:
@@ -235,12 +244,15 @@ func runTick(d time.Duration) tea.Cmd {
 // fetchRunInfo fetches workflow run metadata.
 func fetchRunInfo(ctx context.Context, client *github.Client, token, owner, repo string, runID int64) tea.Cmd {
 	return func() tea.Msg {
-		runInfo, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
+		runInfo, rateLimit, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
 		if err != nil {
 			return RunInfoMsg{Err: err}
 		}
 
-		return RunInfoMsg{RunInfo: *runInfo}
+		return RunInfoMsg{
+			RunInfo:            *runInfo,
+			RateLimitRemaining: rateLimit,
+		}
 	}
 }
 

--- a/internal/tui/runupdate.go
+++ b/internal/tui/runupdate.go
@@ -33,7 +33,7 @@ type RunJobsUpdateMsg struct {
 type RunWorkflowsDiscoveredMsg struct {
 	NewRunIDToWorkflowID map[int64]int64
 	WorkflowIDsToFetch   []int64
-	Err                   error
+	Err                  error
 }
 
 // RunJobAveragesPartialMsg is sent for each workflow that finishes history fetch in run mode.
@@ -50,7 +50,7 @@ type RunErrorMsg struct {
 
 // Init initializes the run model.
 func (m RunModel) Init() tea.Cmd {
-		return tea.Batch(
+	return tea.Batch(
 		m.spinner.Tick,
 		fetchRunInfo(m.ctx, m.client, m.owner, m.repo, m.runID),
 		runTick(m.refreshInterval),
@@ -77,7 +77,7 @@ func (m RunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// (0) before the first successful response doesn't suppress fetches.
 		if m.fetchReceived && m.rateLimitRemaining < rateBackoffThreshold {
 			debug.Log("rate limit backoff (run)", "remaining", m.rateLimitRemaining, "threshold", rateBackoffThreshold)
-			return m, runTick(m.refreshInterval*3)
+			return m, runTick(m.refreshInterval * 3)
 		}
 		return m, tea.Batch(
 			fetchRunJobs(m.ctx, m.client, m.owner, m.repo, m.runID),

--- a/internal/tui/runview.go
+++ b/internal/tui/runview.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/google/go-github/v90/github"
 	ghclient "github.com/fini-net/gh-observer/internal/github"
 	"github.com/fini-net/gh-observer/internal/timing"
+	"github.com/google/go-github/v90/github"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -27,8 +27,8 @@ func (m RunModel) View() tea.View {
 		timeSinceUpdate := time.Since(m.lastUpdate)
 
 		var updatedLine string
-		if m.runInfo.HeadCommitTime != nil && !m.runInfo.HeadCommitTime.IsZero() {
-			timeSincePush := time.Since(m.runInfo.HeadCommitTime.Time)
+		if m.runInfo.HeadPushedTime != nil && !m.runInfo.HeadPushedTime.IsZero() {
+			timeSincePush := time.Since(m.runInfo.HeadPushedTime.Time)
 			updatedLine = fmt.Sprintf("Updated %s ago  •  Pushed %s ago",
 				timing.FormatDuration(timeSinceUpdate),
 				timing.FormatDuration(timeSincePush))

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -545,9 +545,8 @@ func fetchPRInfo(ctx context.Context, token, owner, repo string, prNumber int) t
 			debug.Log("timestamp parse error", "field", "CreatedAt", "value", prInfo.CreatedAt, "err", err)
 		}
 
-		// HeadCommitDate is no longer populated by FetchPRInfo; the push
-		// time now arrives via ChecksUpdateMsg from the GraphQL check-runs
-		// query (issue #349).
+		// The head push time arrives via ChecksUpdateMsg from the GraphQL
+		// check-runs query (FetchCheckRunsGraphQL), not from PRInfo (issue #349).
 
 		return PRInfoMsg{
 			Number:    prInfo.Number,

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -124,7 +124,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.prTitle = msg.Title
 		m.headSHA = msg.HeadSHA
 		m.prCreatedAt = msg.CreatedAt
-		m.headCommitTime = msg.HeadCommitTime
 
 		cmds := []tea.Cmd{
 			fetchCheckRuns(m.ctx, m.token, m.owner, m.repo, m.prNumber),
@@ -325,6 +324,14 @@ func (m *Model) handleChecksUpdate(msg ChecksUpdateMsg) (tea.Model, tea.Cmd) {
 
 	m.checkRuns = msg.CheckRuns
 	SortCheckRuns(m.checkRuns)
+	// Adopt the GraphQL-sourced push time on the first successful poll
+	// where it is non-zero. Subsequent polls overwrite with the same
+	// value; if a later poll returns zero (e.g. transient query shape
+	// change), preserve the last known value rather than dropping the
+	// user-facing "Pushed Xs ago" header.
+	if !msg.HeadPushedTime.IsZero() {
+		m.headPushedTime = msg.HeadPushedTime
+	}
 	m.rateLimitRemaining = msg.RateLimitRemaining
 	m.fetchReceived = true
 	m.lastUpdate = time.Now()
@@ -537,17 +544,16 @@ func fetchPRInfo(ctx context.Context, token, owner, repo string, prNumber int) t
 		if err != nil {
 			debug.Log("timestamp parse error", "field", "CreatedAt", "value", prInfo.CreatedAt, "err", err)
 		}
-		headCommitTime, err := ghclient.ParseTimestamp(prInfo.HeadCommitDate)
-		if err != nil {
-			debug.Log("timestamp parse error", "field", "HeadCommitDate", "value", prInfo.HeadCommitDate, "err", err)
-		}
+
+		// HeadCommitDate is no longer populated by FetchPRInfo; the push
+		// time now arrives via ChecksUpdateMsg from the GraphQL check-runs
+		// query (issue #349).
 
 		return PRInfoMsg{
-			Number:         prInfo.Number,
-			Title:          prInfo.Title,
-			HeadSHA:        prInfo.HeadSHA,
-			CreatedAt:      createdAt,
-			HeadCommitTime: headCommitTime,
+			Number:    prInfo.Number,
+			Title:     prInfo.Title,
+			HeadSHA:   prInfo.HeadSHA,
+			CreatedAt: createdAt,
 		}
 	}
 }
@@ -591,13 +597,14 @@ func fetchWorkflowHistory(ctx context.Context, owner, repo string, workflowID in
 // fetchCheckRuns fetches check runs using GraphQL
 func fetchCheckRuns(ctx context.Context, token, owner, repo string, prNumber int) tea.Cmd {
 	return func() tea.Msg {
-		checkRuns, rateLimit, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
+		checkRuns, headPushedTime, rateLimit, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
 		if err != nil {
 			return ChecksUpdateMsg{Err: err}
 		}
 
 		return ChecksUpdateMsg{
 			CheckRuns:          checkRuns,
+			HeadPushedTime:     headPushedTime,
 			RateLimitRemaining: rateLimit,
 		}
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1397,10 +1397,9 @@ func TestHandleCopilotReview(t *testing.T) {
 		// fetch. The gate must remain unsatisfied while pending and within
 		// max-wait.
 		model, _ := m.Update(PRInfoMsg{
-			Number:         42,
-			Title:          "test",
-			HeadSHA:        "abc123",
-			HeadCommitTime: time.Now(),
+			Number:  42,
+			Title:   "test",
+			HeadSHA: "abc123",
 		})
 		result := model.(Model)
 		if !result.copilotPending {
@@ -1440,10 +1439,9 @@ func TestHandleCopilotReview(t *testing.T) {
 		m.headSHA = "abc123"
 
 		model, _ := m.Update(PRInfoMsg{
-			Number:         42,
-			Title:          "test",
-			HeadSHA:        "abc123",
-			HeadCommitTime: time.Now(),
+			Number:  42,
+			Title:   "test",
+			HeadSHA: "abc123",
 		})
 		result := model.(Model)
 		if !result.copilotPending {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -25,8 +25,8 @@ func (m Model) View() tea.View {
 		timeSinceUpdate := time.Since(m.lastUpdate)
 
 		var updatedLine string
-		if !m.headCommitTime.IsZero() {
-			timeSincePush := time.Since(m.headCommitTime)
+		if !m.headPushedTime.IsZero() {
+			timeSincePush := time.Since(m.headPushedTime)
 			updatedLine = fmt.Sprintf("Updated %s ago  •  Pushed %s ago",
 				timing.FormatDuration(timeSinceUpdate),
 				timing.FormatDuration(timeSincePush))
@@ -61,7 +61,7 @@ func (m Model) View() tea.View {
 		return tea.NewView(b.String() + m.renderStartupPhase())
 	}
 
-	widths := CalculateColumnWidths(m.checkRuns, m.headCommitTime, m.jobAverages)
+	widths := CalculateColumnWidths(m.checkRuns, m.headPushedTime, m.jobAverages)
 
 	// Compute the synthetic Copilot review row once and reuse it for both
 	// column-width widening and the row render. Calling buildCopilotCheckRun
@@ -262,7 +262,7 @@ func (m Model) renderCheckRun(check ghclient.CheckRunInfo, widths ColumnWidths) 
 	nameCol := BuildNameColumn(check, widths, m.enableLinks)
 
 	// Get column data (plain text)
-	queueText := FormatQueueLatency(check, m.headCommitTime)
+	queueText := FormatQueueLatency(check, m.headPushedTime)
 	durationText := FormatDuration(check)
 	avgText := FormatAvg(check, m.jobAverages)
 

--- a/main.go
+++ b/main.go
@@ -436,7 +436,7 @@ func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enable
 		return 1
 	}
 
-	runInfo, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
+	runInfo, _, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch run info: %v\n", err)
 		return 1

--- a/main.go
+++ b/main.go
@@ -342,13 +342,7 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 		return 1
 	}
 
-	headCommitTime, err := time.Parse(time.RFC3339, prInfo.HeadCommitDate)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse commit time: %v\n", err)
-		return 1
-	}
-
-	checkRuns, _, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
+	checkRuns, headPushedTime, _, err := ghclient.FetchCheckRunsGraphQL(ctx, token, owner, repo, prNumber)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch check runs: %v\n", err)
 		return 1
@@ -357,8 +351,12 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 	fmt.Printf("PR #%d: %s\n\n", prNumber, prInfo.Title)
 
 	if len(checkRuns) == 0 {
-		sinceCreation := time.Since(headCommitTime)
-		fmt.Printf("No checks found (commit pushed %s ago)\n", timing.FormatDuration(sinceCreation))
+		if !headPushedTime.IsZero() {
+			sincePush := time.Since(headPushedTime)
+			fmt.Printf("No checks found (commit pushed %s ago)\n", timing.FormatDuration(sincePush))
+		} else {
+			fmt.Println("No checks found")
+		}
 		fmt.Println("Checks may still be starting up or not configured for this PR")
 		return 0
 	}
@@ -379,7 +377,7 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 	}
 	ghclient.ApplyPresumedAverages(jobAverages, checkRuns, presumedAverages)
 
-	widths := tui.CalculateColumnWidths(checkRuns, headCommitTime, jobAverages)
+	widths := tui.CalculateColumnWidths(checkRuns, headPushedTime, jobAverages)
 
 	headerQueue, headerName, headerDuration, headerAvg := tui.FormatHeaderColumns(widths)
 	fmt.Printf("%s   %s  %s  %s\n\n", headerQueue, headerName, headerDuration, headerAvg)
@@ -387,7 +385,7 @@ func runSnapshot(ctx context.Context, token, owner, repo string, prNumber int, e
 	exitCode := 0
 	for _, check := range checkRuns {
 		nameCol := tui.BuildNameColumn(check, widths, enableLinks)
-		queueText := tui.FormatQueueLatency(check, headCommitTime)
+		queueText := tui.FormatQueueLatency(check, headPushedTime)
 		durationText := tui.FormatDuration(check)
 		avgText := tui.FormatAvg(check, jobAverages)
 		icon := tui.GetCheckIcon(check.Status, check.Conclusion)
@@ -451,8 +449,8 @@ func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enable
 	}
 
 	var timeSinceStr string
-	if runInfo.HeadCommitTime != nil && !runInfo.HeadCommitTime.IsZero() {
-		timeSinceStr = fmt.Sprintf("Pushed %s ago", timing.FormatDuration(time.Since(runInfo.HeadCommitTime.Time)))
+	if runInfo.HeadPushedTime != nil && !runInfo.HeadPushedTime.IsZero() {
+		timeSinceStr = fmt.Sprintf("Pushed %s ago", timing.FormatDuration(time.Since(runInfo.HeadPushedTime.Time)))
 	} else if runInfo.CreatedAt != nil && !runInfo.CreatedAt.IsZero() {
 		timeSinceStr = fmt.Sprintf("Created %s ago", timing.FormatDuration(time.Since(runInfo.CreatedAt.Time)))
 	}

--- a/main.go
+++ b/main.go
@@ -436,7 +436,7 @@ func runRunSnapshot(ctx context.Context, owner, repo string, runID int64, enable
 		return 1
 	}
 
-	runInfo, err := ghclient.FetchRunInfo(ctx, client, owner, repo, runID)
+	runInfo, err := ghclient.FetchRunInfo(ctx, client, token, owner, repo, runID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch run info: %v\n", err)
 		return 1


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🤛 [src] use push time instead of commit time, fixes #349
- 🤛 [src] remove dead PRInfo.HeadCommitDate field (review feedback)
- 🤛 [src] thread token through FetchRunInfo instead of re-deriving (review feedback)
- 🤛 [docs] fix GraphQL query reference in CLAUDE.md (review feedback)
- 🤛 [src] track rate limit in run-mode pushedDate GraphQL lookup (review feedback)
- 🤛 [src] drop no-op compile-time guard in runs_test.go (review feedback)

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
